### PR TITLE
Girder dandi archive skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # dandiarchive
 Infrastructure and code for the dandiarchive
+
+Folders in this repo:
+
+- Ansible: Ansible code for deploying the girder.dandiarchive.org site.
+- web: Vue.js code for holding a Girder Web Components based client deployed at gui.dandiarchive.org .
+- girder-dandi-archive: A Girder plugin for customizing the DANDI archive Girder instance.

--- a/girder-dandi-archive/.editorconfig
+++ b/girder-dandi-archive/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.py]
+indent_size = 4
+max_line_length = 100
+
+[*.js]
+indent_size = 4
+
+[*.json]
+indent_size = 4
+
+[*.pug]
+indent_size = 2
+
+[*.styl]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/girder-dandi-archive/.gitignore
+++ b/girder-dandi-archive/.gitignore
@@ -1,0 +1,50 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/

--- a/girder-dandi-archive/LICENSE
+++ b/girder-dandi-archive/LICENSE
@@ -1,0 +1,15 @@
+Apache Software License 2.0
+
+Copyright (c) 2019, michael grauer
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/girder-dandi-archive/MANIFEST.in
+++ b/girder-dandi-archive/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include README.rst
+include setup.py
+
+graft girder_dandi_archive
+graft docs
+prune test
+global-exclude *.py[co] *.cmake __pycache__ node_modules

--- a/girder-dandi-archive/README.rst
+++ b/girder-dandi-archive/README.rst
@@ -1,0 +1,10 @@
+=============
+DANDI Archive
+=============
+
+A Girder plugin used as a prototype DANDI neuroscience archive.
+
+Features
+--------
+
+* TODO

--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -1,0 +1,9 @@
+from girder import plugin
+
+
+class GirderPlugin(plugin.GirderPlugin):
+    DISPLAY_NAME = 'DANDI Archive'
+
+    def load(self, info):
+        # add plugin loading logic here
+        pass

--- a/girder-dandi-archive/requirements-dev.txt
+++ b/girder-dandi-archive/requirements-dev.txt
@@ -1,0 +1,3 @@
+pip>=9
+tox
+virtualenv

--- a/girder-dandi-archive/setup.cfg
+++ b/girder-dandi-archive/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/girder-dandi-archive/setup.py
+++ b/girder-dandi-archive/setup.py
@@ -1,0 +1,41 @@
+from setuptools import setup, find_packages
+
+with open('README.rst') as readme_file:
+    readme = readme_file.read()
+
+requirements = [
+    'girder>=3.0.0a1'
+]
+
+setup(
+    author='michael grauer',
+    author_email='michael.grauer@kitware.com',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'License :: OSI Approved :: Apache Software License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
+    ],
+    description='A Girder plugin used as a prototype DANDI neuroscience archive.',
+    install_requires=requirements,
+    license='Apache Software License 2.0',
+    long_description=readme,
+    long_description_content_type='text/x-rst',
+    include_package_data=True,
+    keywords='girder-plugin, dandi_archive',
+    name='girder_dandi_archive',
+    packages=find_packages(exclude=['test', 'test.*']),
+    url='	https://github.com/dandi/dandiarchive',
+    version='0.1.0',
+    zip_safe=False,
+    entry_points={
+        'girder.plugin': [
+            'dandi_archive = girder_dandi_archive:GirderPlugin'
+        ]
+    }
+)

--- a/girder-dandi-archive/tests/test_load.py
+++ b/girder-dandi-archive/tests/test_load.py
@@ -1,0 +1,8 @@
+import pytest
+
+from girder.plugin import loadedPlugins
+
+
+@pytest.mark.plugin('dandi_archive')
+def test_import(server):
+    assert 'dandi_archive' in loadedPlugins()

--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -1,0 +1,81 @@
+[tox]
+envlist =
+    lint,
+    py3
+
+[testenv]
+deps =
+    coverage
+    mock
+    pytest
+    pytest-cov
+    pytest-girder>=0.1.0a1
+    pytest-xdist
+commands =
+    pytest --cov {envsitepackagesdir}/girder_dandi_archive {posargs}
+
+[testenv:lint]
+skipsdist = true
+skip_install = true
+deps =
+    flake8
+    flake8-blind-except
+    flake8-bugbear
+    flake8-docstrings
+    flake8-quotes
+    pep8-naming
+commands =
+    flake8 {posargs}
+
+[testenv:release]
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
+deps =
+    twine
+commands =
+    twine check {distdir}/*
+    twine upload --skip-existing {distdir}/*
+
+[flake8]
+max-line-length = 100
+show-source = True
+format = pylint
+exclude =
+    node_modules,
+    .eggs,
+    .git,
+    __pycache__,
+    .tox
+ignore =
+    # D10* - Missing docstring in *
+    D10,
+    # E123 - Closing bracket does not match indentation of opening bracket’s line
+    E123
+    # N802 - Function name should be lowercase.
+    N802,
+    # N803 - Argument name should be lowercase.
+    N803,
+    # N806 - Variable in function should be lowercase.
+    N806,
+    # N812 - Lowercase imported as non lowercase.
+    N812,
+    # N815 - mixedCase variable in class scope
+    N815,
+    # N816 - mixedCase variable in global scope
+    N816,
+    # W503 - Line break before binary operator
+    W503,
+
+[pytest]
+addopts = --verbose --strict --showlocals --cov-report="term"
+testpaths = tests
+
+[coverage:paths]
+source =
+    girder_dandi_archive/
+    .tox/*/lib/python*/site-packages/girder_dandi_archive/
+
+[coverage:run]
+branch = True
+parallel = True


### PR DESCRIPTION
@dorukozturk 

This creates a skeleton girder plugin that you can use for sdist packaging/Ansible deployment.

Are you ok to merge this so we can base further work on it? I created it using the [Cookiecutter Girder Plugin](https://github.com/girder/cookiecutter-girder-plugin) and tested that it installs cleanly on a local instance.