### PR TITLE
Stub dandi search as standard text search

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -1,9 +1,9 @@
 from girder import plugin
+from girder.utility import search
 
 
 class GirderPlugin(plugin.GirderPlugin):
     DISPLAY_NAME = 'DANDI Archive'
 
     def load(self, info):
-        # add plugin loading logic here
-        pass
+        search.addSearchMode('dandi', search.getSearchModeHandler('text'))


### PR DESCRIPTION
This creates a custom `dandi` search mode, which provides a pass-through to the standard `text` search mode.

This is just a stop-gap so that @subdavis has a plugin to test an alternate search mode with.