### PR TITLE
Add dandi archive proxy for vue client

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_API_ROOT=https://girder.dandiarchive.org/api/v1


### PR DESCRIPTION
Combined with the following Girder CORS setting, this should make the vue client hit the correct api url.

```
https://gui.dandiarchive.org
```

.env.production file is added which sets the VUE_APP_API_ROOT parameter when:
```
yarn run build
```
command is run.   