### PR TITLE
Jupyter link in details view

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@girder/components": "girder/girder_web_components#feature/details",
+    "@girder/components": "^2.0.2",
     "core-js": "^2.6.5",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3",

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -14,7 +14,7 @@
             @selection-changed="setSelected" />
       </v-col>
       <v-col cols="4" v-if="selected.length">
-        <girder-data-details :value="selected"/>
+        <girder-data-details :value="selected" :action-keys="actions" />
       </v-col>
     </v-row>
   </v-container>
@@ -23,11 +23,28 @@
 <script>
 import { mapGetters, mapMutations, mapState } from 'vuex';
 import { Authentication as GirderAuth, DataDetails as GirderDataDetails } from '@girder/components/src/components';
+import { DefaultActionKeys } from '@girder/components/src/components/DataDetails.vue';
 import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+
+const JUPYTER_ROOT = process.env.JUPYTER_ROOT || '/jupyter/some_notebook'; // TODO url
+const actionKeys = [
+  {
+    for: ['item'],
+    name: 'Open in Jupyter',
+    icon: 'mdi-language-python',
+    color: 'primary',
+    handler() {
+      const { value: items } = this;
+      window.open(`${JUPYTER_ROOT}?item=${items[0]._id}`, '_blank');
+    },
+  },
+  ...DefaultActionKeys,
+];
 
 export default {
   components: { GirderAuth, GirderDataDetails, GirderFileManager },
   computed: {
+    actions: () => actionKeys,
     location: {
       get() {
         return this.browseLocation;

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -669,9 +669,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@girder/components@girder/girder_web_components#feature/details":
-  version "2.0.1"
-  resolved "https://codeload.github.com/girder/girder_web_components/tar.gz/88298f6fb9cc046429f97b7bdeaf0875242b13da"
+"@girder/components@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@girder/components/-/components-2.0.2.tgz#d35cd748f2d9a5f73554b8c9bb5e65dc0b99c0e8"
+  integrity sha512-FNd7z791Ys2nGxkKbHlRrLQ7EW3j7sdYHsHvdOPDcwgtDoPVzvBVhMEtBFs7ld9gGiB1dA31GNfQ1/ZmsJOn0w==
   dependencies:
     "@mdi/font" "^3.5.95"
     axios "^0.18.1"


### PR DESCRIPTION
This incorporates all the recent upgrades to DataDetails in upstream GWC:

![Screen Shot 2019-10-10 at 2 15 09 PM](https://user-images.githubusercontent.com/555959/66595156-63807580-eb68-11e9-9623-01f3579029db.png)
