### PR TITLE
Test org membership during OAuth login

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -1,9 +1,35 @@
-from girder import plugin
+import os
+import requests
+
+from girder import events, plugin
+from girder.exceptions import AccessException
 from girder.utility import search
+from girder_oauth.providers import github
+
+_GH_ORG = os.environ.get('DANDI_GITHUB_ORG', 'dandi')
+
+
+def _checkOrgMembership(event):
+    token = event.info['token']['access_token']
+    headers = {
+        'Authorization': f'token {token}',
+        'Accept': 'application/json'
+    }
+    # Must get username in order to do the check membership request
+    resp = requests.get(f'https://api.github.com/user', headers=headers)
+    resp.raise_for_status()
+    username = resp.json()['login']
+
+    resp = requests.get(f'https://api.github.com/orgs/{_GH_ORG}/members/{username}', headers=headers)
+    if resp.status_code != 204:
+        raise AccessException(f'This user is not a member of the {_GH_ORG} GitHub org.')
 
 
 class GirderPlugin(plugin.GirderPlugin):
     DISPLAY_NAME = 'DANDI Archive'
 
     def load(self, info):
+        plugin.getPlugin('oauth').load(info)
         search.addSearchMode('dandi', search.getSearchModeHandler('text'))
+        events.bind('oauth.auth_callback.before', 'dandi_archive', _checkOrgMembership)
+        github.GitHub.addScopes(['read:org'])

--- a/girder-dandi-archive/setup.py
+++ b/girder-dandi-archive/setup.py
@@ -4,7 +4,8 @@ with open('README.rst') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'girder>=3.0.0a1'
+    'girder>=3.0.0a1',
+    'requests'
 ]
 
 setup(


### PR DESCRIPTION
Note that in order for this to work, the oauth app must be granted special access at the *org* level here: https://github.com/organizations/dandi/settings/oauth_application_policy

Once it's approved, all users of that oauth client can have their org membership tested, regardless of whether their membership status is public or private.

As of now, if the test fails, we raise an exception, which ends up simply printing some ugly text in the user's browser. We really should do an HTTP redirect instead, and take them to a human-readable page telling them what they should do to be able to log into the system. I'm leaving that as future work for now.