### PR TITLE
Remove hashsum_download plugin

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -36,11 +36,20 @@
         name:
           - girder-oauth
           - girder-sentry
-          - girder-hashsum-download
           - girder-download-statistics
           - "git+https://github.com/dandi/dandiarchive@{{ lookup('env', 'CIRCLE_SHA1') }}#subdirectory=girder-dandi-archive"
         virtualenv: "{{ girder_virtualenv }}"
         state: latest
+      notify:
+        - Build Girder web client
+        - Restart Girder
+
+    - name: Remove Girder plugins
+      pip:
+        name:
+          - girder-hashsum-download
+        virtualenv: "{{ girder_virtualenv }}"
+        state: absent
       notify:
         - Build Girder web client
         - Restart Girder


### PR DESCRIPTION
Remove the girder hashsum_download plugin in order to provide a performance baseline as we start to upload files.

This is a "migration" style PR that should be followed up with a removal of the state:absent section.