### PR TITLE
Add URL routing for directory and selected item

### DIFF
--- a/web/src/router.js
+++ b/web/src/router.js
@@ -7,8 +7,13 @@ Vue.use(Router);
 export default new Router({
   routes: [
     {
-      path: '/',
+      path: '/:_modelType?/:_id?',
       name: 'home',
+      component: Home,
+    },
+    {
+      path: '/:_modelType?/:_id/selected/:ids+',
+      name: 'home2',
       component: Home,
     },
   ],

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,0 +1,30 @@
+function getLocationFromRoute(route) {
+  const { _modelType, _id } = route.params;
+  if (_modelType) {
+    return { _modelType, _id };
+  }
+  return null;
+}
+
+function getPathFromLocation(location) {
+  if (!location) {
+    return '/';
+  }
+  return `/${location._modelType || location.type}${location._id ? `/${location._id}` : ''}`;
+}
+
+function getSelectedFromRoute(route) {
+  const { ids } = route.params;
+  return ids ? ids.split('/').map(item => item.split('+')).map(([type, id]) => ({ _id: id, _modelType: type })) : [];
+}
+
+function getPathFromSelected(selected) {
+  if (!selected.length) {
+    return '';
+  }
+  return `/selected/${selected.map(model => `${model._modelType}+${model._id}`).join('/')}`;
+}
+
+export {
+  getLocationFromRoute, getPathFromLocation, getSelectedFromRoute, getPathFromSelected,
+};

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -27,6 +27,13 @@ import { Authentication as GirderAuth, DataDetails as GirderDataDetails } from '
 import { DefaultActionKeys } from '@girder/components/src/components/DataDetails.vue';
 import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
 
+import {
+  getPathFromLocation,
+  getLocationFromRoute,
+  getSelectedFromRoute,
+  getPathFromSelected,
+} from '@/utils';
+
 const JUPYTER_ROOT = process.env.JUPYTER_ROOT || '/jupyter/some_notebook'; // TODO url
 const actionKeys = [
   {
@@ -56,6 +63,43 @@ export default {
     },
     ...mapState(['browseLocation', 'selected']),
     ...mapGetters(['loggedIn']),
+  },
+  watch: {
+    browseLocation(value) {
+      const newPath = getPathFromLocation(value) + getPathFromSelected(this.selected);
+      if (this.$route.path !== newPath) {
+        this.$router.push(newPath);
+      }
+    },
+    selected(selected) {
+      const newPath = getPathFromLocation(this.location) + getPathFromSelected(selected);
+      if (this.$route.path !== newPath) {
+        this.$router.push(newPath);
+      }
+    },
+    $route(to) {
+      const location = getLocationFromRoute(to);
+      const selected = getSelectedFromRoute(to);
+      if (location._id !== this.location._id) {
+        this.location = location;
+      }
+      if (
+        selected.length !== this.selected.length
+        || selected
+          .find((model, i) => model._id !== (this.selected[i] ? this.selected[i]._id : null))
+      ) {
+        // Same reason as what it says in store.js
+        this.$nextTick(() => {
+          this.setSelected(selected);
+        });
+      }
+    },
+  },
+  created() {
+    const location = getLocationFromRoute(this.$route);
+    const selected = getSelectedFromRoute(this.$route);
+    this.setBrowseLocation(location);
+    this.setSelected(selected);
   },
   methods: mapMutations(['setBrowseLocation', 'setSelected']),
 };


### PR DESCRIPTION
Add functionality to sync URL and browser location and selection.
However, due to the current implementation of DataBrowser, multi-selected items won't have correct metadata at page loads. However, this behavior probably is acceptable at this moment. 

Resolve https://github.com/dandi/dandiarchive/issues/41