### PR TITLE
Change browser page size

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@girder/components": "git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9",
+    "@girder/components": "git+https://github.com/girder/girder_web_components.git#791b9f2714089a15173e541d20622ea2e66a3cf8",
     "@sentry/browser": "^5.7.0",
     "@sentry/integrations": "^5.7.0",
     "core-js": "^2.6.5",

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -12,7 +12,9 @@
             :location.sync="location"
             :upload-enabled="false"
             :value="selected"
-            @input="setSelected" />
+            @input="setSelected"
+            :initial-items-per-page="25"
+            :items-per-page-options="[10,25,50,100,-1]" />
       </v-col>
       <v-col cols="4" v-if="selected.length">
         <girder-data-details :value="selected" :action-keys="actions" />

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -669,9 +669,9 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@girder/components@git+https://github.com/girder/girder_web_components.git#0a9995406b088c04d9b0225b504f402f2a642c1b":
+"@girder/components@git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9":
   version "2.0.2"
-  resolved "git+https://github.com/girder/girder_web_components.git#0a9995406b088c04d9b0225b504f402f2a642c1b"
+  resolved "git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9"
   dependencies:
     "@mdi/font" "^3.5.95"
     axios "^0.18.1"
@@ -683,9 +683,9 @@
     vue-async-computed "^3.4.1"
     vuetify "^2.1.10"
 
-"@girder/components@git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9":
+"@girder/components@git+https://github.com/girder/girder_web_components.git#791b9f2714089a15173e541d20622ea2e66a3cf8":
   version "2.0.2"
-  resolved "git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9"
+  resolved "git+https://github.com/girder/girder_web_components.git#791b9f2714089a15173e541d20622ea2e66a3cf8"
   dependencies:
     "@mdi/font" "^3.5.95"
     axios "^0.18.1"


### PR DESCRIPTION
With the upgraded GWC, it's possible to customize page sizes and the default page size. 
However, Girder doesn't have good support for 'all' option at this moment. So 'all' option is removed at this moment. 

Resolve https://github.com/dandi/dandiarchive/issues/42