### PR TITLE
Add Early Access tooltip to app bar

### DIFF
--- a/web/src/components/DandiAppBar.vue
+++ b/web/src/components/DandiAppBar.vue
@@ -3,6 +3,17 @@
     <v-toolbar-title>
       <img class="logo" alt="DANDI logo" height="48px" src="../assets/logo.svg" />
     </v-toolbar-title>
+    <v-tooltip right>
+      <template v-slot:activator="{ on }">
+        <v-chip class="ml-2" color="secondary" v-on="on">
+          <v-icon left color="amber">$vuetify.icons.alert</v-icon>Early Access
+        </v-chip>
+      </template>
+      <span>
+        DANDI is currently running in limited access mode.
+        Public release isn't until March 2020.
+      </span>
+    </v-tooltip>
     <v-spacer/>
     <girder-search @select="selectSearchResult" search-mode="dandi"
         :search-types="['item']" :hide-options-menu="true" placeholder="Type search query" >

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -669,20 +669,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@girder/components@git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9":
-  version "2.0.2"
-  resolved "git+https://github.com/girder/girder_web_components.git#393a48e9dc94a7d5350e711f1fb68a3bf3898ff9"
-  dependencies:
-    "@mdi/font" "^3.5.95"
-    axios "^0.18.1"
-    js-cookie "^2.2.0"
-    markdown-it "^8.4.2"
-    moment "^2.24.0"
-    qs "^6.5.2"
-    vue "^2.6.10"
-    vue-async-computed "^3.4.1"
-    vuetify "^2.1.10"
-
 "@girder/components@git+https://github.com/girder/girder_web_components.git#791b9f2714089a15173e541d20622ea2e66a3cf8":
   version "2.0.2"
   resolved "git+https://github.com/girder/girder_web_components.git#791b9f2714089a15173e541d20622ea2e66a3cf8"


### PR DESCRIPTION
Fixes #75. I've included 2 screenshots below showing the tooltip with and without the hover effect.

![Screenshot from 2020-01-22 17-04-50](https://user-images.githubusercontent.com/11370025/72938739-801c7400-3d39-11ea-9f3e-1f7ae8e2cebc.png)
![Screenshot from 2020-01-22 17-04-48](https://user-images.githubusercontent.com/11370025/72938740-801c7400-3d39-11ea-8b4f-4567f6a0fff9.png)
