### PR TITLE
Add create and get dandiset endpoints

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -7,10 +7,10 @@ from girder.utility import search
 
 
 class GirderPlugin(GirderPlugin):
-    DISPLAY_NAME = 'DANDI Archive'
+    DISPLAY_NAME = "DANDI Archive"
 
     def load(self, info):
-        search.addSearchMode('dandi', dandi_search_handler)
+        search.addSearchMode("dandi", dandi_search_handler)
 
 
 def dandi_search_handler(query, types, user=None, level=None, limit=0, offset=0):
@@ -22,14 +22,16 @@ def dandi_search_handler(query, types, user=None, level=None, limit=0, offset=0)
             # specifying the query using the search DSL.
             items = []
         else:
-            items = list(Item().findWithPermissions(query=query, types=types, user=user))
+            items = list(
+                Item().findWithPermissions(query=query, types=types, user=user)
+            )
             for item in items:
-                item['_modelType'] = 'item'  # TODO why is this necessary to provide?
+                item["_modelType"] = "item"  # TODO why is this necessary to provide?
     except SyntaxError:
         items = []
     except ValueError:
         items = []
-    return {'item': items}  # TODO similarly why is this necessary to provide?
+    return {"item": items}  # TODO similarly why is this necessary to provide?
     # TODO those are questions around the search handler api more than anything
 
 
@@ -37,18 +39,23 @@ def tokenize_search_string(search_string):
     search_string = search_string.lower()
     tokens = search_string.split()
     # use '+' as a space inside a token, e.g. nuo+li => 'nuo li'
-    tokens = [token.replace('+', ' ') for token in tokens]
+    tokens = [token.replace("+", " ") for token in tokens]
     return tokens
 
 
 def extract_key_values(tokens):
     key_values = {}
     for tok in tokens:
-        if ':' in tok:
-            if tok == ':' or tok.count(':') > 1 or tok.startswith(':') or tok.endswith(':'):
-                raise SyntaxError('Malformed key value pair')
+        if ":" in tok:
+            if (
+                tok == ":"
+                or tok.count(":") > 1
+                or tok.startswith(":")
+                or tok.endswith(":")
+            ):
+                raise SyntaxError("Malformed key value pair")
             else:
-                key, value = tok.split(':')
+                key, value = tok.split(":")
                 values = key_values.get(key, [])
                 values.append(value)
                 key_values[key] = values
@@ -58,99 +65,109 @@ def extract_key_values(tokens):
 def add_search_key_values(key_values):
     search_keys = {
         # See https://www.crossref.org/blog/dois-and-matching-regular-expressions/
-        'doi': {
-            'arity': 'multiple',
-            'regex': r"""^10.\d{4,9}/[-._;()/:a-zA-Z0-9]+$""",
-            'values': [],
-            'meta_key': 'related_publications',
+        "doi": {
+            "arity": "multiple",
+            "regex": r"""^10.\d{4,9}/[-._;()/:a-zA-Z0-9]+$""",
+            "values": [],
+            "meta_key": "related_publications",
         },
-        'keyword': {'arity': 'multiple', 'values': [], 'meta_key': 'keywords'},
-        'experimenter': {'arity': 'single', 'values': []},
+        "keyword": {"arity": "multiple", "values": [], "meta_key": "keywords"},
+        "experimenter": {"arity": "single", "values": []},
         # TODO ?? how will we keep these clean and do searches
         # with spaces, commas, first name, last name, different spellings?
         # non-first name/last name, utf-8 ??
         # TODO most proximate issue is with space between first and last name
-        'lab': {'arity': 'single', 'values': []},
-        'institution': {'arity': 'single', 'values': []},
-        'subject_id': {'arity': 'single', 'values': []},
-        'identifier': {'arity': 'single', 'values': []},
-        'session_id': {'arity': 'single', 'values': []},
-        'units': {'arity': 'more_fewer', 'min': None, 'max': None, 'meta_key': 'number_of_units'},
-        'electrodes': {
-            'arity': 'more_fewer',
-            'min': None,
-            'max': None,
-            'meta_key': 'number_of_units',
+        "lab": {"arity": "single", "values": []},
+        "institution": {"arity": "single", "values": []},
+        "subject_id": {"arity": "single", "values": []},
+        "identifier": {"arity": "single", "values": []},
+        "session_id": {"arity": "single", "values": []},
+        "units": {
+            "arity": "more_fewer",
+            "min": None,
+            "max": None,
+            "meta_key": "number_of_units",
+        },
+        "electrodes": {
+            "arity": "more_fewer",
+            "min": None,
+            "max": None,
+            "meta_key": "number_of_units",
         },
     }
     for key, values in key_values.items():
         for value in values:
             if key not in search_keys.keys():
                 # Check if a more_fewer key
-                m = re.search('^(more|fewer)_(.*)_than$', key)
+                m = re.search("^(more|fewer)_(.*)_than$", key)
                 if m:
                     more_fewer, search_key = m.group(1), m.group(2)
                     if (
                         search_key in search_keys.keys()
-                        and search_keys[search_key]['arity'] == 'more_fewer'
+                        and search_keys[search_key]["arity"] == "more_fewer"
                     ):
-                        if more_fewer == 'more':
-                            if search_keys[search_key]['min']:
-                                raise ValueError('Only one value for %s allowed') % key
+                        if more_fewer == "more":
+                            if search_keys[search_key]["min"]:
+                                raise ValueError("Only one value for %s allowed") % key
                             else:
-                                search_keys[search_key]['min'] = value
+                                search_keys[search_key]["min"] = value
                                 continue
                         else:
-                            if search_keys[search_key]['max']:
-                                raise ValueError('Only one value for %s allowed') % key
+                            if search_keys[search_key]["max"]:
+                                raise ValueError("Only one value for %s allowed") % key
                             else:
-                                search_keys[search_key]['max'] = value
+                                search_keys[search_key]["max"] = value
                                 continue
             else:
-                if search_keys[key]['arity'] == 'single' and len(search_keys[key]['values']) > 1:
-                    raise ValueError('Only one value for %s allowed') % key
-                search_keys[key]['values'].append(value)
+                if (
+                    search_keys[key]["arity"] == "single"
+                    and len(search_keys[key]["values"]) > 1
+                ):
+                    raise ValueError("Only one value for %s allowed") % key
+                search_keys[key]["values"].append(value)
                 continue
-            raise ValueError('Invalid key %s' % key)
+            raise ValueError("Invalid key %s" % key)
     return search_keys
 
 
 def validate_search_key_values(search_keys):
     for key, search_data in search_keys.items():
-        if search_data['arity'] == 'more_fewer' and (search_data['min'] or search_data['max']):
-            if search_data['min']:
-                search_data['min'] = int(search_data['min'])
-                if search_data['min'] < 0:
-                    raise ValueError('%s min value must be at least 0' % key)
-            if search_keys[key]['max']:
-                search_data['max'] = int(search_data['max'])
-                if search_data['max'] < 1:
-                    raise ValueError('%s max value must be at least 1' % key)
+        if search_data["arity"] == "more_fewer" and (
+            search_data["min"] or search_data["max"]
+        ):
+            if search_data["min"]:
+                search_data["min"] = int(search_data["min"])
+                if search_data["min"] < 0:
+                    raise ValueError("%s min value must be at least 0" % key)
+            if search_keys[key]["max"]:
+                search_data["max"] = int(search_data["max"])
+                if search_data["max"] < 1:
+                    raise ValueError("%s max value must be at least 1" % key)
             if (
-                search_data['min']
-                and search_data['max']
-                and search_data['min'] >= search_data['max']
+                search_data["min"]
+                and search_data["max"]
+                and search_data["min"] >= search_data["max"]
             ):
-                raise ValueError('%s min value must be less than max value' % key)
-        if 'regex' in search_keys[key]:
-            for value in search_keys[key]['values']:
-                result = re.match(search_keys[key]['regex'], value)
+                raise ValueError("%s min value must be less than max value" % key)
+        if "regex" in search_keys[key]:
+            for value in search_keys[key]["values"]:
+                result = re.match(search_keys[key]["regex"], value)
                 if result is None:
-                    raise ValueError('Invalid value %s for key %s' % (value, key))
+                    raise ValueError("Invalid value %s for key %s" % (value, key))
 
 
 def get_mongo_key(key, search_data):
-    if 'meta_key' in search_data:
-        search_term = search_data['meta_key']
+    if "meta_key" in search_data:
+        search_term = search_data["meta_key"]
     else:
         search_term = key
-    search_term = 'meta.%s' % search_term
+    search_term = "meta.%s" % search_term
     return search_term
 
 
 def get_mongo_value(search_arity, search_values):
-    if search_arity == 'multiple' and len(search_values) > 1:
-        mongo_value = {'$all': search_values}
+    if search_arity == "multiple" and len(search_values) > 1:
+        mongo_value = {"$all": search_values}
     else:
         mongo_value = search_values[0]
     return mongo_value
@@ -158,12 +175,12 @@ def get_mongo_value(search_arity, search_values):
 
 def get_mongo_more_fewer_value(min, max):
     if min and max:
-        return {'$gt': min, '$lt': max}
+        return {"$gt": min, "$lt": max}
     else:
         if min:
-            return {'$gt': min}
+            return {"$gt": min}
         if max:
-            return {'$lt': max}
+            return {"$lt": max}
 
 
 def build_query_from_query_terms(search_keys):
@@ -172,10 +189,16 @@ def build_query_from_query_terms(search_keys):
     for key, search_data in search_keys.items():
         mongo_key = get_mongo_key(key, search_data)
         # set something with values, either single or multiple
-        if 'values' in search_data and search_data['values']:
-            query[mongo_key] = get_mongo_value(search_data['arity'], search_data['values'])
-        elif search_data['arity'] == 'more_fewer' and (search_data['min'] or search_data['max']):
-            query[mongo_key] = get_mongo_more_fewer_value(search_data['min'], search_data['max'])
+        if "values" in search_data and search_data["values"]:
+            query[mongo_key] = get_mongo_value(
+                search_data["arity"], search_data["values"]
+            )
+        elif search_data["arity"] == "more_fewer" and (
+            search_data["min"] or search_data["max"]
+        ):
+            query[mongo_key] = get_mongo_more_fewer_value(
+                search_data["min"], search_data["max"]
+            )
     return query
 
 

--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -5,12 +5,15 @@ from girder.plugin import GirderPlugin
 from girder.models.item import Item
 from girder.utility import search
 
+from .rest import DandiResource
+
 
 class GirderPlugin(GirderPlugin):
     DISPLAY_NAME = "DANDI Archive"
 
     def load(self, info):
         search.addSearchMode("dandi", dandi_search_handler)
+        info["apiRoot"].dandi = DandiResource()
 
 
 def dandi_search_handler(query, types, user=None, level=None, limit=0, offset=0):

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -28,7 +28,14 @@ class DandiResource(Resource):
         .param("description", "Description of the Dandiset.")
     )
     def create_dandiset(self, params):
+        if "name" not in params or "description" not in params:
+            raise RestException("Name and description required.")
+
         name, description = params["name"], params["description"]
+
+        if not name or not description:
+            raise RestException("Name and description must not be empty.")
+
         exists = Folder().findOne({"name": name})
 
         if exists:

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -5,7 +5,12 @@ from girder.models.setting import Setting
 from girder.models.folder import Folder
 from girder.exceptions import RestException
 
-from .util import DANDI_ID_COUNTER, staging_collection, pad_dandi_id, validate_dandi_id
+from .util import (
+    DANDISET_ID_COUNTER,
+    staging_collection,
+    pad_dandiset_id,
+    validate_dandiset_id,
+)
 
 
 @access.user
@@ -21,13 +26,13 @@ def create_dandiset(params):
     if exists:
         raise RestException("Dandiset already exists", code=409)
 
-    current = Setting().get(DANDI_ID_COUNTER)
+    current = Setting().get(DANDISET_ID_COUNTER)
     if current is None:
-        new_id_count = Setting().set(DANDI_ID_COUNTER, 0)
+        new_id_count = Setting().set(DANDISET_ID_COUNTER, 0)
     else:
-        new_id_count = Setting().set(DANDI_ID_COUNTER, current + 1)
+        new_id_count = Setting().set(DANDISET_ID_COUNTER, current + 1)
 
-    padded_id = pad_dandi_id(new_id_count["value"])
+    padded_id = pad_dandiset_id(new_id_count["value"])
     meta = {"name": name, "description": description, "id": padded_id}
 
     staging = staging_collection()
@@ -41,7 +46,7 @@ def create_dandiset(params):
 @access.public
 @describeRoute(Description("Get Dandiset").param("id", "Dandiset ID"))
 def get_dandiset(params):
-    if not validate_dandi_id(params["id"]):
+    if not validate_dandiset_id(params["id"]):
         raise RestException("Invalid Dandiset ID")
 
     doc = Folder().findOne({"meta.dandiset.id": params["id"]})

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -36,9 +36,9 @@ class DandiResource(Resource):
 
         current = Setting().get(DANDISET_ID_COUNTER)
         if current is None:
-            new_id_count = Setting().set(DANDISET_ID_COUNTER, 0)
-        else:
-            new_id_count = Setting().set(DANDISET_ID_COUNTER, current + 1)
+            current = -1
+
+        new_id_count = Setting().set(DANDISET_ID_COUNTER, current + 1)
 
         padded_id = pad_dandiset_id(new_id_count["value"])
         meta = {"name": name, "description": description, "id": padded_id}

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -51,11 +51,7 @@ class DandiResource(Resource):
 
         staging = staging_collection()
         folder = Folder().createFolder(
-            staging,
-            name,
-            parentType="collection",
-            creator=self.getCurrentUser(),
-            public=False,
+            staging, name, parentType="collection", creator=self.getCurrentUser(),
         )
         folder = Folder().setMetadata(folder, {"dandiset": meta})
         return folder

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -1,0 +1,61 @@
+from girder.api import access
+from girder.api.rest import Resource
+from girder.api.describe import describeRoute, Description
+from girder.models.setting import Setting
+from girder.models.folder import Folder
+from girder.utility import setting_utilities
+from girder.exceptions import ValidationException, RestException
+
+from .util import DANDI_ID_COUNTER, DANDI_ID_LENGTH, staging_collection, pad_dandi_id
+
+
+@access.public
+@describeRoute(
+    Description("Create Dandiset")
+    .param("name", "Name of the Dandiset.")
+    .param("description", "Description of the Dandiset.")
+)
+def create_dandiset(params):
+    name, description = params["name"], params["description"]
+    exists = Folder().findOne({"name": name})
+
+    if exists:
+        raise RestException("Dandiset already exists", code=409)
+
+    current = Setting().get(DANDI_ID_COUNTER)
+    if current is None:
+        new_id_count = Setting().set(DANDI_ID_COUNTER, 0)
+    else:
+        new_id_count = Setting().set(DANDI_ID_COUNTER, current + 1)
+
+    padded_id = pad_dandi_id(new_id_count["value"])
+    meta = {"dandiset": {"name": name, "description": description, "id": padded_id}}
+
+    staging = staging_collection()
+    folder = Folder().createFolder(
+        staging, name, parentType="collection", public=False,
+    )
+    folder = Folder().setMetadata(folder, meta)
+    return folder
+
+
+@setting_utilities.validator(DANDI_ID_COUNTER)
+def _validate(doc):
+    if len(str(doc["value"])) > DANDI_ID_LENGTH:
+        raise ValidationException("Dandiset ID limit exceeded", "value")
+
+
+@access.public
+@describeRoute(Description("Get Dandiset").param("id", "Dandiset ID"))
+def get_dandiset(params):
+    doc = Folder().findOne({"meta.dandiset.id": params["id"]})
+    return doc
+
+
+class DandiResource(Resource):
+    def __init__(self):
+        super(DandiResource, self).__init__()
+
+        self.resourceName = "dandi"
+        self.route("GET", (), get_dandiset)
+        self.route("POST", (), create_dandiset)

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -7,8 +7,8 @@ from girder.exceptions import RestException
 
 from .util import (
     DANDISET_ID_COUNTER,
+    DANDISET_ID_LENGTH,
     staging_collection,
-    pad_dandiset_id,
     validate_dandiset_id,
 )
 
@@ -45,9 +45,8 @@ class DandiResource(Resource):
         if current is None:
             current = -1
 
-        new_id_count = Setting().set(DANDISET_ID_COUNTER, current + 1)
-
-        padded_id = pad_dandiset_id(new_id_count["value"])
+        new_id_count = Setting().set(DANDISET_ID_COUNTER, current + 1)["value"]
+        padded_id = f"{new_id_count:0{DANDISET_ID_LENGTH}d}"
         meta = {"name": name, "description": description, "id": padded_id}
 
         staging = staging_collection()

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -21,14 +21,6 @@ def validate_dandiset_id(dandiset_id):
     return bool(re.match(dandiset_id_pattern, dandiset_id))
 
 
-def pad_dandiset_id(dandiset_id):
-    id_str = str(dandiset_id)
-    length = len(str(id_str))
-    remaining = DANDISET_ID_LENGTH - length
-
-    return "%s%s" % (remaining * "0", id_str)
-
-
 def staging_collection():
     doc = Collection().findOne({"name": DANDI_STAGING_COLLECTION_NAME})
 

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -1,0 +1,24 @@
+from girder.models.collection import Collection
+
+DANDI_ID_COUNTER = "dandi.id_counter"
+DANDI_ID_LENGTH = 6
+DANDI_STAGING_COLLECTION_NAME = "Dandiset Staging"
+
+
+def pad_dandi_id(dandi_id):
+    id_str = str(dandi_id)
+    length = len(str(id_str))
+    remaining = DANDI_ID_LENGTH - length
+
+    return "%s%s" % (remaining * "0", id_str)
+
+
+def staging_collection():
+    doc = Collection().findOne({
+        "name": DANDI_STAGING_COLLECTION_NAME
+    })
+
+    if doc is None:
+        doc = Collection().createCollection(DANDI_STAGING_COLLECTION_NAME, public=False)
+
+    return doc

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -4,27 +4,27 @@ from girder.models.collection import Collection
 from girder.utility import setting_utilities
 from girder.exceptions import ValidationException
 
-DANDI_ID_COUNTER = "dandi.id_counter"
-DANDI_ID_LENGTH = 6
+DANDISET_ID_COUNTER = "dandi.id_counter"
+DANDISET_ID_LENGTH = 6
 DANDI_STAGING_COLLECTION_NAME = "Dandiset Staging"
 
-dandi_id_pattern = r"^\d{6}$"
+dandiset_id_pattern = r"^\d{6}$"
 
 
-@setting_utilities.validator(DANDI_ID_COUNTER)
+@setting_utilities.validator(DANDISET_ID_COUNTER)
 def _validate(doc):
-    if len(str(doc["value"])) > DANDI_ID_LENGTH:
+    if len(str(doc["value"])) > DANDISET_ID_LENGTH:
         raise ValidationException("Dandiset ID limit exceeded", "value")
 
 
-def validate_dandi_id(dandi_id):
-    return bool(re.match(dandi_id_pattern, dandi_id))
+def validate_dandiset_id(dandiset_id):
+    return bool(re.match(dandiset_id_pattern, dandiset_id))
 
 
-def pad_dandi_id(dandi_id):
-    id_str = str(dandi_id)
+def pad_dandiset_id(dandiset_id):
+    id_str = str(dandiset_id)
     length = len(str(id_str))
-    remaining = DANDI_ID_LENGTH - length
+    remaining = DANDISET_ID_LENGTH - length
 
     return "%s%s" % (remaining * "0", id_str)
 

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -1,8 +1,24 @@
+import re
+
 from girder.models.collection import Collection
+from girder.utility import setting_utilities
+from girder.exceptions import ValidationException
 
 DANDI_ID_COUNTER = "dandi.id_counter"
 DANDI_ID_LENGTH = 6
 DANDI_STAGING_COLLECTION_NAME = "Dandiset Staging"
+
+dandi_id_pattern = r"^\d{6}$"
+
+
+@setting_utilities.validator(DANDI_ID_COUNTER)
+def _validate(doc):
+    if len(str(doc["value"])) > DANDI_ID_LENGTH:
+        raise ValidationException("Dandiset ID limit exceeded", "value")
+
+
+def validate_dandi_id(dandi_id):
+    return bool(re.match(dandi_id_pattern, dandi_id))
 
 
 def pad_dandi_id(dandi_id):
@@ -14,9 +30,7 @@ def pad_dandi_id(dandi_id):
 
 
 def staging_collection():
-    doc = Collection().findOne({
-        "name": DANDI_STAGING_COLLECTION_NAME
-    })
+    doc = Collection().findOne({"name": DANDI_STAGING_COLLECTION_NAME})
 
     if doc is None:
         doc = Collection().createCollection(DANDI_STAGING_COLLECTION_NAME, public=False)

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -22,9 +22,6 @@ def validate_dandiset_id(dandiset_id):
 
 
 def staging_collection():
-    doc = Collection().findOne({"name": DANDI_STAGING_COLLECTION_NAME})
-
-    if doc is None:
-        doc = Collection().createCollection(DANDI_STAGING_COLLECTION_NAME, public=False)
-
-    return doc
+    return Collection().createCollection(
+        DANDI_STAGING_COLLECTION_NAME, reuseExisting=True,
+    )

--- a/girder-dandi-archive/setup.cfg
+++ b/girder-dandi-archive/setup.cfg
@@ -1,2 +1,6 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+inline-quotes = double
+multiline-quotes = """

--- a/girder-dandi-archive/setup.cfg
+++ b/girder-dandi-archive/setup.cfg
@@ -1,6 +1,2 @@
 [bdist_wheel]
 universal = 1
-
-[flake8]
-inline-quotes = double
-multiline-quotes = """

--- a/girder-dandi-archive/setup.py
+++ b/girder-dandi-archive/setup.py
@@ -1,45 +1,43 @@
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'girder>=3.0.0a1',
-    'girder-download-statistics',
-    'girder-homepage',
-    'girder-oauth',
-    'girder-sentry'
+    "girder>=3.0.0a1",
+    "girder-download-statistics",
+    "girder-homepage",
+    "girder-oauth",
+    "girder-sentry",
 ]
 
 setup(
-    author='michael grauer',
-    author_email='michael.grauer@kitware.com',
+    author="michael grauer",
+    author_email="michael.grauer@kitware.com",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        "Development Status :: 2 - Pre-Alpha",
+        "License :: OSI Approved :: Apache Software License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
-    description='A Girder plugin used as a prototype DANDI neuroscience archive.',
+    description="A Girder plugin used as a prototype DANDI neuroscience archive.",
     install_requires=requirements,
-    license='Apache Software License 2.0',
+    license="Apache Software License 2.0",
     long_description=readme,
-    long_description_content_type='text/x-rst',
+    long_description_content_type="text/x-rst",
     include_package_data=True,
-    keywords='girder-plugin, dandi_archive',
-    name='girder_dandi_archive',
-    packages=find_packages(exclude=['test', 'test.*']),
-    url='	https://github.com/dandi/dandiarchive',
-    version='0.1.0',
+    keywords="girder-plugin, dandi_archive",
+    name="girder_dandi_archive",
+    packages=find_packages(exclude=["test", "test.*"]),
+    url="	https://github.com/dandi/dandiarchive",
+    version="0.1.0",
     zip_safe=False,
     entry_points={
-        'girder.plugin': [
-            'dandi_archive = girder_dandi_archive:GirderPlugin'
-        ]
-    }
+        "girder.plugin": ["dandi_archive = girder_dandi_archive:GirderPlugin"]
+    },
 )

--- a/girder-dandi-archive/tests/test_load.py
+++ b/girder-dandi-archive/tests/test_load.py
@@ -3,6 +3,6 @@ import pytest
 from girder.plugin import loadedPlugins
 
 
-@pytest.mark.plugin('dandi_archive')
+@pytest.mark.plugin("dandi_archive")
 def test_import(server):
-    assert 'dandi_archive' in loadedPlugins()
+    assert "dandi_archive" in loadedPlugins()

--- a/girder-dandi-archive/tests/test_plugin.py
+++ b/girder-dandi-archive/tests/test_plugin.py
@@ -2,38 +2,49 @@ import pytest
 from girder_dandi_archive import convert_search_to_mongo_query, dandi_search_handler
 
 
-@pytest.mark.plugin('dandi_archive')
+@pytest.mark.plugin("dandi_archive")
 @pytest.mark.parametrize(
-    ['string', 'expected'],
-    [('more_units_than:3', {'meta.number_of_units': {'$gt': 3}}),
-     ('more_units_than:3 fewer_units_than:20', {'meta.number_of_units': {'$gt': 3, '$lt': 20}}),
-     ('doi:10.1101/354340', {'meta.related_publications': '10.1101/354340'}),
-     ('keyword:mouse', {'meta.keywords': 'mouse'}),
-     ('keyword:mouse keyword:burgle', {'meta.keywords': {'$all': ['mouse', 'burgle']}})]
+    ["string", "expected"],
+    [
+        ("more_units_than:3", {"meta.number_of_units": {"$gt": 3}}),
+        (
+            "more_units_than:3 fewer_units_than:20",
+            {"meta.number_of_units": {"$gt": 3, "$lt": 20}},
+        ),
+        ("doi:10.1101/354340", {"meta.related_publications": "10.1101/354340"}),
+        ("keyword:mouse", {"meta.keywords": "mouse"}),
+        (
+            "keyword:mouse keyword:burgle",
+            {"meta.keywords": {"$all": ["mouse", "burgle"]}},
+        ),
+    ],
 )
 def test_valid_search_strings(string, expected):
     assert convert_search_to_mongo_query(string) == expected
 
 
-@pytest.mark.plugin('dandi_archive')
+@pytest.mark.plugin("dandi_archive")
 @pytest.mark.parametrize(
-    ['string', 'error', 'message'],
-    [(':', SyntaxError, 'Malformed key value pair'),
-     ('key:', SyntaxError, 'Malformed key value pair'),
-     ('key:key:value', SyntaxError, 'Malformed key value pair'),
-     (':value', SyntaxError, 'Malformed key value pair'),
-     ('number_of_shrews:3', ValueError, 'Invalid key number_of_shrews'),
-     ('doi:doi.org/10.1101/354340', ValueError, 'Invalid value doi.org/10.1101/354340 for key doi')]
+    ["string", "error", "message"],
+    [
+        (":", SyntaxError, "Malformed key value pair"),
+        ("key:", SyntaxError, "Malformed key value pair"),
+        ("key:key:value", SyntaxError, "Malformed key value pair"),
+        (":value", SyntaxError, "Malformed key value pair"),
+        ("number_of_shrews:3", ValueError, "Invalid key number_of_shrews"),
+        (
+            "doi:doi.org/10.1101/354340",
+            ValueError,
+            "Invalid value doi.org/10.1101/354340 for key doi",
+        ),
+    ],
 )
 def test_invalid_search_strings(string, error, message):
     with pytest.raises(error, match=message):
         convert_search_to_mongo_query(string)
 
 
-@pytest.mark.plugin('dandi_archive')
-@pytest.mark.parametrize(
-    ['query_string', 'expected'],
-    [('abracadabra', {'item': []})]
-)
+@pytest.mark.plugin("dandi_archive")
+@pytest.mark.parametrize(["query_string", "expected"], [("abracadabra", {"item": []})])
 def test_dandi_search_handler_with_random_string(query_string, expected):
-    assert dandi_search_handler(query_string, ['item']) == expected
+    assert dandi_search_handler(query_string, ["item"]) == expected

--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -40,6 +40,8 @@ commands =
 [flake8]
 max-line-length = 100
 show-source = True
+inline-quotes = double
+multiline-quotes = double
 format = pylint
 exclude =
     node_modules,


### PR DESCRIPTION
Fixes #88.
Fixes #80.

This PR adds two endpoints:

1. An endpoint to create a dandiset, creating a folder with the specified name under the staging collection and assigning it an ID
2. An endpoint to get the girder folder document from a given dandiset ID

If viewing the file changes, please ignore the first commit, as it's just a formatting change.