### PR TITLE
BF: Girder folder for created dataset should be named with the id

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -51,7 +51,7 @@ class DandiResource(Resource):
 
         staging = staging_collection()
         folder = Folder().createFolder(
-            staging, name, parentType="collection", creator=self.getCurrentUser(),
+            staging, padded_id, parentType="collection", creator=self.getCurrentUser(),
         )
         folder = Folder().setMetadata(folder, {"dandiset": meta})
         return folder


### PR DESCRIPTION
not metadata 'name'.  Since otherwise we get something like https://girder.dandiarchive.org/#collection/5e59bb0af19e820ab6ea6c62 -- where name, later edited, also does not even correspond to the name of the folder.