### PR TITLE
enh: create a ui element for dataset registration

### DIFF
--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -1,9 +1,11 @@
 FROM node
 
-COPY web /client
+COPY web/package.json /client/package.json
 WORKDIR /client
 RUN npm install
+COPY web /client
 RUN yarn run build --mode docker
 
 FROM nginx
+RUN rm -rf /usr/share/nginx/html/*
 COPY --from=0 /client/dist /usr/share/nginx/html

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,6 @@
     "filesize": "^6.0.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
-    "qs": "^6.5.2",
     "vue": "^2.6.10",
     "vue-json-pretty": "^1.6.3",
     "vue-router": "^3.0.3",

--- a/web/package.json
+++ b/web/package.json
@@ -16,6 +16,7 @@
     "filesize": "^6.0.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
+    "qs": "^6.5.2",
     "vue": "^2.6.10",
     "vue-json-pretty": "^1.6.3",
     "vue-router": "^3.0.3",

--- a/web/src/components/DandiAppBar.vue
+++ b/web/src/components/DandiAppBar.vue
@@ -11,6 +11,47 @@
       <span>You are currently viewing the data portal.
       Click this button to learn more about the DANDI project.</span>
     </v-tooltip>
+    <v-dialog max-width="600px">
+      <template v-slot:activator="{ on }">
+        <v-btn text :disabled="!loggedIn"
+               class="ml-2 white--text" dark v-on="on">Register</v-btn>
+      </template>
+      <v-card>
+        <v-card-title>
+          <span class="headline">Register a new dataset</span>
+        </v-card-title>
+        <v-card-text>
+          <v-container>
+            <v-row>
+              <v-col cols="12">
+                <v-text-field label="Name*"
+                              hint="Provide a title for this dataset"
+                              persistent-hint
+                              :counter="120"
+                              required></v-text-field>
+              </v-col>
+              <v-col cols="12">
+                <v-textarea label="Description*"
+                              hint="Provide a description for this dataset"
+                              :counter="3000"
+                              persistent-hint
+                              required></v-textarea>
+              </v-col>
+            </v-row>
+          </v-container>
+          <small>*indicates required field</small>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn type="submit" color="primary" @click="call_api">
+            Register dataset
+            <template v-slot:loader>
+              <span>Registering...</span>
+            </template>
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-tooltip bottom>
       <template v-slot:activator="{ on }">
         <v-chip class="ml-2" color="secondary" v-on="on">

--- a/web/src/components/DandiAppBar.vue
+++ b/web/src/components/DandiAppBar.vue
@@ -11,7 +11,7 @@
       <span>You are currently viewing the data portal.
       Click this button to learn more about the DANDI project.</span>
     </v-tooltip>
-    <v-dialog max-width="600px">
+    <v-dialog max-width="600px" v-model="regdialog">
       <template v-slot:activator="{ on }">
         <v-btn text :disabled="!loggedIn"
                class="ml-2 white--text" dark v-on="on">Register</v-btn>
@@ -134,6 +134,7 @@ export default {
    data: () => ({
     name: '',
     description: '',
+    regdialog: false,
   }),
   components: { GirderSearch, GirderAuth },
   computed: {
@@ -173,7 +174,7 @@ export default {
         this.$router.push({
             name: 'dandiset-metadata-viewer',
             params: { id: data['_id'] } });
-        // TODO: close the dialog
+        this.regdialog = false;
       }
     },
       ...mapActions(['logout', 'selectSearchResult'])

--- a/web/src/components/DandiAppBar.vue
+++ b/web/src/components/DandiAppBar.vue
@@ -13,41 +13,47 @@
     </v-tooltip>
     <v-dialog max-width="600px" v-model="regdialog">
       <template v-slot:activator="{ on }">
-        <v-btn text :disabled="!loggedIn"
-               class="ml-2 white--text" dark v-on="on">Register</v-btn>
+        <v-btn
+          text
+          :disabled="!loggedIn"
+          class="ml-2 white--text"
+          dark
+          v-on="on"
+        >
+          Register
+        </v-btn>
       </template>
       <v-card>
         <v-card-title>
           <span class="headline">Register a new dataset</span>
         </v-card-title>
         <v-card-text>
-          <v-container>
-            <v-row>
-              <v-col cols="12">
-                <v-text-field label="Name*"
-                              hint="Provide a title for this dataset"
-                              persistent-hint
-                              :counter="120"
-                              v-model="name"
-                              required></v-text-field>
-              </v-col>
-              <v-col cols="12">
-                <v-textarea label="Description*"
-                              hint="Provide a description for this dataset"
-                              :counter="3000"
-                              persistent-hint
-                              v-model="description"
-                              required></v-textarea>
-              </v-col>
-            </v-row>
-          </v-container>
+          <v-text-field
+            label="Name*"
+            hint="Provide a title for this dataset"
+            persistent-hint
+            :counter="120"
+            v-model="name"
+            required
+          />
+          <v-textarea
+            label="Description*"
+            hint="Provide a description for this dataset"
+            :counter="3000"
+            persistent-hint
+            v-model="description"
+            required
+          />
           <small>*indicates required field</small>
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn type="submit" color="primary"
-                 :disabled="saveDisabled"
-                 @click="register_dandiset">
+          <v-btn
+            type="submit"
+            color="primary"
+            :disabled="saveDisabled"
+            @click="register_dandiset"
+          >
             Register dataset
             <template v-slot:loader>
               <span>Registering...</span>
@@ -126,12 +132,11 @@
 </template>
 
 <script>
-import { stringify } from 'qs';
 import { mapActions, mapGetters, mapState } from 'vuex';
 import { Search as GirderSearch, Authentication as GirderAuth } from '@girder/components/src/components';
 
 export default {
-   data: () => ({
+  data: () => ({
     name: '',
     description: '',
     regdialog: false,
@@ -139,12 +144,10 @@ export default {
   components: { GirderSearch, GirderAuth },
   computed: {
     saveDisabled() {
-      return this.name === "" || this.description === "";
+      return !(this.name && this.description);
     },
     ...mapGetters(['loggedIn', 'user']),
-    ...mapState({
-      girderRest: 'girderRest',
-    }),
+    ...mapState(['girderRest']),
     version() {
       return process.env.VUE_APP_VERSION;
     },
@@ -165,19 +168,19 @@ export default {
   methods: {
     async register_dandiset() {
       const { name, description } = this;
-      const { status, data } = await this.girderRest.post(`dandi`,
-          stringify({ name: name, description: description}));
+      const { status, data } = await this.girderRest.post('dandi', null, { params: { name, description } });
 
       if (status === 200) {
         this.name = '';
         this.description = '';
         this.$router.push({
-            name: 'dandiset-metadata-viewer',
-            params: { id: data['_id'] } });
+          name: 'dandiset-metadata-viewer',
+          params: { id: data._id },
+        });
         this.regdialog = false;
       }
     },
-      ...mapActions(['logout', 'selectSearchResult'])
+    ...mapActions(['logout', 'selectSearchResult']),
   },
 };
 </script>


### PR DESCRIPTION
This is a quick attempt at a UI element for dataset registration. It works (with updates to my local girder regarding drafts collection). 

but one thing i could not fix is how to get vue to rerender the component. i read a few things, but i think someone with more knowledge can take care of this faster.

to see the issue:
create a dataset -> should take you to the landing page
now create another dataset --> this will not refresh the contents of the existing landing page.
