### PR TITLE
Test dandiset endpoints

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -3,15 +3,22 @@ import re
 
 from girder.plugin import GirderPlugin
 from girder.models.item import Item
+from girder.models.setting import Setting
 from girder.utility import search
 
 from .rest import DandiResource
+from .util import DANDISET_IDENTIFIER_COUNTER
 
 
 class GirderPlugin(GirderPlugin):
     DISPLAY_NAME = "DANDI Archive"
 
     def load(self, info):
+        Setting().collection.update(
+            {"key": DANDISET_IDENTIFIER_COUNTER},
+            {"$setOnInsert": {"value": 0}},
+            upsert=True,
+        )
         search.addSearchMode("dandi", dandi_search_handler)
         info["apiRoot"].dandi = DandiResource()
 

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -9,7 +9,7 @@ from .util import (
     DANDISET_IDENTIFIER_COUNTER,
     DANDISET_IDENTIFIER_LENGTH,
     create_drafts_collection,
-    validate_dandiset_identifier
+    validate_dandiset_identifier,
 )
 
 
@@ -53,7 +53,7 @@ class DandiResource(Resource):
             "version": "draft",
         }
 
-        drafts = drafts_collection()
+        drafts = create_drafts_collection()
         folder = Folder().createFolder(
             drafts,
             padded_identifier,
@@ -85,13 +85,13 @@ class DandiResource(Resource):
         if not version in ["draft"]:
             raise RestException('Invalid Dandiset Version, must be one of ["draft"]')
 
-        # Ensure we are only looking for staging collection child folders.
-        staging = create_staging_collection()
+        # Ensure we are only looking for drafts collection child folders.
+        drafts = create_drafts_collection()
         doc = Folder().findOne(
             {
                 "baseParentType": "collection",
-                "baseParentId": staging["_id"],
-                "parentId": staging["_id"],
+                "baseParentId": drafts["_id"],
+                "parentId": drafts["_id"],
                 "meta.dandiset.identifier": identifier,
                 "meta.dandiset.version": version,
             }

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -8,7 +8,7 @@ from girder.exceptions import RestException
 from .util import (
     DANDISET_IDENTIFIER_COUNTER,
     DANDISET_IDENTIFIER_LENGTH,
-    create_drafts_collection,
+    get_or_create_drafts_collection,
     validate_dandiset_identifier,
 )
 
@@ -50,7 +50,7 @@ class DandiResource(Resource):
             "version": "draft",
         }
 
-        drafts = create_drafts_collection()
+        drafts = get_or_create_drafts_collection()
         folder = Folder().createFolder(
             drafts,
             padded_identifier,
@@ -79,20 +79,18 @@ class DandiResource(Resource):
 
         if not validate_dandiset_identifier(identifier):
             raise RestException("Invalid Dandiset Identifier")
-        if not version in ["draft"]:
+        if version not in ["draft"]:
             raise RestException('Invalid Dandiset Version, must be one of ["draft"]')
 
         # Ensure we are only looking for drafts collection child folders.
-        drafts = create_drafts_collection()
+        drafts = get_or_create_drafts_collection()
         doc = Folder().findOne(
             {
-                "baseParentType": "collection",
-                "baseParentId": drafts["_id"],
                 "parentId": drafts["_id"],
                 "meta.dandiset.identifier": identifier,
                 "meta.dandiset.version": version,
             }
         )
         if not doc:
-            doc = {}
+             raise RestException('No such dandiset found.')
         return doc

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -47,7 +47,6 @@ class DandiResource(Resource):
             "name": name,
             "description": description,
             "identifier": padded_identifier,
-            "version": "draft",
         }
 
         drafts = get_or_create_drafts_collection()
@@ -62,34 +61,24 @@ class DandiResource(Resource):
 
     @access.public
     @describeRoute(
-        Description("Get Dandiset")
-        .param("identifier", "Dandiset Identifier")
-        .param(
-            "version", 'Version of the Dandiset, currently only "draft" is supported.'
-        )
+        Description("Get Dandiset").param("identifier", "Dandiset Identifier")
     )
     def get_dandiset(self, params):
-        if "identifier" not in params or "version" not in params:
-            raise RestException("identifier and version required.")
+        if "identifier" not in params:
+            raise RestException("identifier required.")
 
-        identifier, version = params["identifier"], params["version"]
+        identifier = params["identifier"]
 
-        if not identifier or not version:
-            raise RestException("identifier and version must not be empty.")
+        if not identifier:
+            raise RestException("identifier must not be empty.")
 
         if not validate_dandiset_identifier(identifier):
             raise RestException("Invalid Dandiset Identifier")
-        if version not in ["draft"]:
-            raise RestException('Invalid Dandiset Version, must be one of ["draft"]')
 
         # Ensure we are only looking for drafts collection child folders.
         drafts = get_or_create_drafts_collection()
         doc = Folder().findOne(
-            {
-                "parentId": drafts["_id"],
-                "meta.dandiset.identifier": identifier,
-                "meta.dandiset.version": version,
-            }
+            {"parentId": drafts["_id"], "meta.dandiset.identifier": identifier}
         )
         if not doc:
             raise RestException("No such dandiset found.")

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -92,5 +92,5 @@ class DandiResource(Resource):
             }
         )
         if not doc:
-             raise RestException('No such dandiset found.')
+            raise RestException("No such dandiset found.")
         return doc

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -36,14 +36,11 @@ class DandiResource(Resource):
         if not name or not description:
             raise RestException("Name and description must not be empty.")
 
-        # TODO look into atomic update
-        # TODO break into submethod
-        current = Setting().get(DANDISET_IDENTIFIER_COUNTER)
-        if current is None:
-            current = -1
-        new_identifier_count = Setting().set(DANDISET_IDENTIFIER_COUNTER, current + 1)[
-            "value"
-        ]
+        new_identifier_count = Setting().collection.find_one_and_update(
+            {"key": DANDISET_IDENTIFIER_COUNTER},
+            {"$inc": {"value": 1}},
+            projection={"value": True},
+        )["value"]
         padded_identifier = f"{new_identifier_count:0{DANDISET_IDENTIFIER_LENGTH}d}"
 
         meta = {

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -4,24 +4,24 @@ from girder.models.collection import Collection
 from girder.utility import setting_utilities
 from girder.exceptions import ValidationException
 
-DANDISET_ID_COUNTER = "dandi.id_counter"
-DANDISET_ID_LENGTH = 6
+DANDISET_IDENTIFIER_COUNTER = "dandi.identifier_counter"
+DANDISET_IDENTIFIER_LENGTH = 6
 DANDI_STAGING_COLLECTION_NAME = "Dandiset Staging"
 
-dandiset_id_pattern = r"^\d{6}$"
+dandiset_identifier_pattern = r"^\d{6}$"
 
 
-@setting_utilities.validator(DANDISET_ID_COUNTER)
+@setting_utilities.validator(DANDISET_IDENTIFIER_COUNTER)
 def _validate(doc):
-    if len(str(doc["value"])) > DANDISET_ID_LENGTH:
-        raise ValidationException("Dandiset ID limit exceeded", "value")
+    if len(str(doc["value"])) > DANDISET_IDENTIFIER_LENGTH:
+        raise ValidationException("Dandiset IDENTIFIER limit exceeded", "value")
 
 
-def validate_dandiset_id(dandiset_id):
-    return bool(re.match(dandiset_id_pattern, dandiset_id))
+def validate_dandiset_identifier(dandiset_identifier):
+    return bool(re.match(dandiset_identifier_pattern, dandiset_identifier))
 
 
-def staging_collection():
+def create_staging_collection():
     return Collection().createCollection(
-        DANDI_STAGING_COLLECTION_NAME, reuseExisting=True,
+        DANDI_STAGING_COLLECTION_NAME, reuseExisting=True
     )

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -23,5 +23,5 @@ def validate_dandiset_identifier(dandiset_identifier):
 
 def create_drafts_collection():
     return Collection().createCollection(
-        DANDI_DRAFTS_COLLECTION_NAME, reuseExisting=True,
+        DANDI_DRAFTS_COLLECTION_NAME, reuseExisting=True
     )

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -21,7 +21,7 @@ def validate_dandiset_identifier(dandiset_identifier):
     return bool(re.match(dandiset_identifier_pattern, dandiset_identifier))
 
 
-def create_drafts_collection():
+def get_or_create_drafts_collection():
     return Collection().createCollection(
         DANDI_DRAFTS_COLLECTION_NAME, reuseExisting=True
     )

--- a/girder-dandi-archive/tests/test_rest.py
+++ b/girder-dandi-archive/tests/test_rest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from girder_dandi_archive.util import create_drafts_collection
+from girder_dandi_archive.util import get_or_create_drafts_collection
 
 from girder.models.collection import Collection
 from girder.models.folder import Folder
@@ -8,6 +8,9 @@ from girder.models.folder import Folder
 from pytest_girder.assertions import assertStatus, assertStatusOk
 
 
+# TODO: This fixture and these tests are not well structured and hard to maintain.
+# They currently work correctly in terms of the application code that they test,
+# but they should be rewritten and not followed as an example.
 @pytest.fixture
 def draftsFolders(db):
     red_herring_collection = Collection().createCollection(
@@ -33,7 +36,7 @@ def draftsFolders(db):
         "red_herring_collection": red_herring_collection,
         "red_herring_folder": red_herring_dandiset_000000_folder,
     }
-    return_dict["drafts_collection"] = create_drafts_collection()
+    return_dict["drafts_collection"] = get_or_create_drafts_collection()
     yield return_dict
 
 
@@ -93,8 +96,7 @@ def testGetDandiset(server, draftsFolders, user, capsys):
         user=user,
         params={"identifier": "000000", "version": "draft"},
     )
-    assertStatusOk(resp)
-    assert resp.json == {}
+    assertStatus(resp, 400)
 
     # Create a Dandiset.
     resp = server.request(

--- a/girder-dandi-archive/tests/test_rest.py
+++ b/girder-dandi-archive/tests/test_rest.py
@@ -1,0 +1,127 @@
+import pytest
+
+from girder_dandi_archive.util import create_staging_collection
+
+from girder.models.collection import Collection
+from girder.models.folder import Folder
+
+from pytest_girder.assertions import assertStatus, assertStatusOk
+
+
+@pytest.fixture
+def stagingFolders(db):
+    red_herring_collection = Collection().createCollection(
+        "red_herring_collection", reuseExisting=True
+    )
+    # A folder that matches dandiset metadata, but not in staging collection.
+    red_herring_dandiset_000000_folder = Folder().createFolder(
+        parent=red_herring_collection,
+        parentType="collection",
+        name="000000",
+        public=True,
+    )
+    meta = {
+        "dandiset": {
+            "name": "red",
+            "description": "herring",
+            "identifier": "000000",
+            "version": "draft",
+        }
+    }
+    Folder().setMetadata(red_herring_dandiset_000000_folder, meta)
+    return_dict = {
+        "red_herring_collection": red_herring_collection,
+        "red_herring_folder": red_herring_dandiset_000000_folder,
+    }
+    return_dict["staging_collection"] = create_staging_collection()
+    yield return_dict
+
+
+@pytest.mark.plugin("dandi_archive")
+def testCreateDandiset(server, stagingFolders, user):
+    staging_collection_id = str(stagingFolders["staging_collection"]["_id"])
+
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={
+            "name": "test dandiset 0 name",
+            "description": "test dandiset 0 description",
+        },
+    )
+    assertStatusOk(resp)
+    test_dandiset_0_folder = resp.json
+    test_dandiset_0_folder_meta = test_dandiset_0_folder["meta"]["dandiset"]
+
+    assert staging_collection_id == test_dandiset_0_folder["parentId"]
+    assert "000000" == test_dandiset_0_folder["name"]
+    assert "000000" == test_dandiset_0_folder_meta["identifier"]
+    assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
+    assert "test dandiset 0 description" == test_dandiset_0_folder_meta["description"]
+    assert "draft" == test_dandiset_0_folder_meta["version"]
+
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={
+            "name": "test dandiset 1 name",
+            "description": "test dandiset 1 description",
+        },
+    )
+    assertStatusOk(resp)
+    test_dandiset_1_folder = resp.json
+    test_dandiset_1_folder_meta = test_dandiset_1_folder["meta"]["dandiset"]
+
+    assert staging_collection_id == test_dandiset_1_folder["parentId"]
+    assert "000001" == test_dandiset_1_folder["name"]
+    assert "000001" == test_dandiset_1_folder_meta["identifier"]
+    assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
+    assert "test dandiset 1 description" == test_dandiset_1_folder_meta["description"]
+    assert "draft" == test_dandiset_1_folder_meta["version"]
+
+
+@pytest.mark.plugin("dandi_archive")
+def testGetDandiset(server, stagingFolders, user, capsys):
+    staging_collection_id = str(stagingFolders["staging_collection"]["_id"])
+
+    # Ensure we don't find any before creation, in the wrong parent.
+    resp = server.request(
+        path="/dandi",
+        method="GET",
+        user=user,
+        params={"identifier": "000000", "version": "draft"},
+    )
+    assertStatusOk(resp)
+    assert resp.json == {}
+
+    # Create a Dandiset.
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={
+            "name": "test dandiset 0 name",
+            "description": "test dandiset 0 description",
+        },
+    )
+    assertStatusOk(resp)
+    assert "000000" == resp.json["meta"]["dandiset"]["identifier"]
+
+    # Ensure we can retrieve the Dandiset.
+    resp = server.request(
+        path="/dandi",
+        method="GET",
+        user=user,
+        params={"identifier": "000000", "version": "draft"},
+    )
+    assertStatusOk(resp)
+    test_dandiset_0_folder = resp.json
+    test_dandiset_0_folder_meta = test_dandiset_0_folder["meta"]["dandiset"]
+    assert staging_collection_id == test_dandiset_0_folder["parentId"]
+    assert "000000" == test_dandiset_0_folder["name"]
+    assert "000000" == test_dandiset_0_folder_meta["identifier"]
+    assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
+    assert "test dandiset 0 description" == test_dandiset_0_folder_meta["description"]
+    assert "draft" == test_dandiset_0_folder_meta["version"]

--- a/girder-dandi-archive/tests/test_rest.py
+++ b/girder-dandi-archive/tests/test_rest.py
@@ -1,6 +1,6 @@
 import pytest
 
-from girder_dandi_archive.util import create_staging_collection
+from girder_dandi_archive.util import create_drafts_collection
 
 from girder.models.collection import Collection
 from girder.models.folder import Folder
@@ -9,11 +9,11 @@ from pytest_girder.assertions import assertStatus, assertStatusOk
 
 
 @pytest.fixture
-def stagingFolders(db):
+def draftsFolders(db):
     red_herring_collection = Collection().createCollection(
         "red_herring_collection", reuseExisting=True
     )
-    # A folder that matches dandiset metadata, but not in staging collection.
+    # A folder that matches dandiset metadata, but not in drafts collection.
     red_herring_dandiset_000000_folder = Folder().createFolder(
         parent=red_herring_collection,
         parentType="collection",
@@ -33,13 +33,13 @@ def stagingFolders(db):
         "red_herring_collection": red_herring_collection,
         "red_herring_folder": red_herring_dandiset_000000_folder,
     }
-    return_dict["staging_collection"] = create_staging_collection()
+    return_dict["drafts_collection"] = create_drafts_collection()
     yield return_dict
 
 
 @pytest.mark.plugin("dandi_archive")
-def testCreateDandiset(server, stagingFolders, user):
-    staging_collection_id = str(stagingFolders["staging_collection"]["_id"])
+def testCreateDandiset(server, draftsFolders, user):
+    drafts_collection_id = str(draftsFolders["drafts_collection"]["_id"])
 
     resp = server.request(
         path="/dandi",
@@ -54,7 +54,7 @@ def testCreateDandiset(server, stagingFolders, user):
     test_dandiset_0_folder = resp.json
     test_dandiset_0_folder_meta = test_dandiset_0_folder["meta"]["dandiset"]
 
-    assert staging_collection_id == test_dandiset_0_folder["parentId"]
+    assert drafts_collection_id == test_dandiset_0_folder["parentId"]
     assert "000000" == test_dandiset_0_folder["name"]
     assert "000000" == test_dandiset_0_folder_meta["identifier"]
     assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
@@ -74,7 +74,7 @@ def testCreateDandiset(server, stagingFolders, user):
     test_dandiset_1_folder = resp.json
     test_dandiset_1_folder_meta = test_dandiset_1_folder["meta"]["dandiset"]
 
-    assert staging_collection_id == test_dandiset_1_folder["parentId"]
+    assert drafts_collection_id == test_dandiset_1_folder["parentId"]
     assert "000001" == test_dandiset_1_folder["name"]
     assert "000001" == test_dandiset_1_folder_meta["identifier"]
     assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
@@ -83,8 +83,8 @@ def testCreateDandiset(server, stagingFolders, user):
 
 
 @pytest.mark.plugin("dandi_archive")
-def testGetDandiset(server, stagingFolders, user, capsys):
-    staging_collection_id = str(stagingFolders["staging_collection"]["_id"])
+def testGetDandiset(server, draftsFolders, user, capsys):
+    drafts_collection_id = str(draftsFolders["drafts_collection"]["_id"])
 
     # Ensure we don't find any before creation, in the wrong parent.
     resp = server.request(
@@ -119,7 +119,7 @@ def testGetDandiset(server, stagingFolders, user, capsys):
     assertStatusOk(resp)
     test_dandiset_0_folder = resp.json
     test_dandiset_0_folder_meta = test_dandiset_0_folder["meta"]["dandiset"]
-    assert staging_collection_id == test_dandiset_0_folder["parentId"]
+    assert drafts_collection_id == test_dandiset_0_folder["parentId"]
     assert "000000" == test_dandiset_0_folder["name"]
     assert "000000" == test_dandiset_0_folder_meta["identifier"]
     assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]

--- a/girder-dandi-archive/tests/test_rest.py
+++ b/girder-dandi-archive/tests/test_rest.py
@@ -24,12 +24,7 @@ def draftsFolders(db):
         public=True,
     )
     meta = {
-        "dandiset": {
-            "name": "red",
-            "description": "herring",
-            "identifier": "000000",
-            "version": "draft",
-        }
+        "dandiset": {"name": "red", "description": "herring", "identifier": "000000"}
     }
     Folder().setMetadata(red_herring_dandiset_000000_folder, meta)
     return_dict = {
@@ -62,7 +57,6 @@ def testCreateDandiset(server, draftsFolders, user):
     assert "000000" == test_dandiset_0_folder_meta["identifier"]
     assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
     assert "test dandiset 0 description" == test_dandiset_0_folder_meta["description"]
-    assert "draft" == test_dandiset_0_folder_meta["version"]
 
     resp = server.request(
         path="/dandi",
@@ -82,7 +76,6 @@ def testCreateDandiset(server, draftsFolders, user):
     assert "000001" == test_dandiset_1_folder_meta["identifier"]
     assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
     assert "test dandiset 1 description" == test_dandiset_1_folder_meta["description"]
-    assert "draft" == test_dandiset_1_folder_meta["version"]
 
 
 @pytest.mark.plugin("dandi_archive")
@@ -91,10 +84,7 @@ def testGetDandiset(server, draftsFolders, user, capsys):
 
     # Ensure we don't find any before creation, in the wrong parent.
     resp = server.request(
-        path="/dandi",
-        method="GET",
-        user=user,
-        params={"identifier": "000000", "version": "draft"},
+        path="/dandi", method="GET", user=user, params={"identifier": "000000"}
     )
     assertStatus(resp, 400)
 
@@ -113,10 +103,7 @@ def testGetDandiset(server, draftsFolders, user, capsys):
 
     # Ensure we can retrieve the Dandiset.
     resp = server.request(
-        path="/dandi",
-        method="GET",
-        user=user,
-        params={"identifier": "000000", "version": "draft"},
+        path="/dandi", method="GET", user=user, params={"identifier": "000000"}
     )
     assertStatusOk(resp)
     test_dandiset_0_folder = resp.json
@@ -126,4 +113,3 @@ def testGetDandiset(server, draftsFolders, user, capsys):
     assert "000000" == test_dandiset_0_folder_meta["identifier"]
     assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
     assert "test dandiset 0 description" == test_dandiset_0_folder_meta["description"]
-    assert "draft" == test_dandiset_0_folder_meta["version"]

--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -74,11 +74,7 @@ ignore =
 
 [pytest]
 # We use the `--forked` option to run tests in subprocesses, which is much slower.
-# This is necessary due to the use of the `server` pytest fixture combined with a
-# custom search mode that this plugin has added. As custom search modes are never
-# removed, when the plugin is re-initialized, it will fail when the custom
-# search mode is re-added.
-# Using this option is the reason for the inclusion of the `pytest-forked` package.
+# See https://github.com/girder/girder/issues/3206
 addopts = --verbose --strict --showlocals --cov-report="term" --forked
 testpaths = tests
 

--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -70,7 +70,7 @@ ignore =
     W503,
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="term"
+addopts = --verbose --strict --showlocals --cov-report="term" --boxed
 testpaths = tests
 
 [coverage:paths]

--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -10,7 +10,7 @@ deps =
     pytest
     pytest-cov
     pytest-girder>=0.1.0a1
-    pytest-xdist
+    pytest-forked
 commands =
     pytest --cov {envsitepackagesdir}/girder_dandi_archive {posargs}
 
@@ -73,7 +73,13 @@ ignore =
     W503,
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="term" --boxed
+# We use the `--forked` option to run tests in subprocesses, which is much slower.
+# This is necessary due to the use of the `server` pytest fixture combined with a
+# custom search mode that this plugin has added. As custom search modes are never
+# removed, when the plugin is re-initialized, it will fail when the custom
+# search mode is re-added.
+# Using this option is the reason for the inclusion of the `pytest-forked` package.
+addopts = --verbose --strict --showlocals --cov-report="term" --forked
 testpaths = tests
 
 [coverage:paths]


### PR DESCRIPTION
Fixes #107, #109.

For #107, this PR updates all uses of `id` in dandiset metadata to `identifier`, and adds in a dandiset metadata key `version`.

This PR also builds on top of #115 by changing all uses of `staging` to `drafts`. It uses `draft` as the initial dandiset metadata value for the key `version`.

After we merge this PR we will need to do the following migrations:
 - remove the dandiset identifier counter setting
 - redo the two existing dandisets (we should just re-create them as that is safer) to give them the correct metadata structure and names
