### PR TITLE
BF: docker - Provide unique prefix (dandi_) to all images/volumes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,14 +4,15 @@ services:
   mongo:
     image: mongo:latest
     volumes:
-      - mongo_db:/data/db
+      - dandi_girder_mongo_db:/data/db
 
   girder:
     build:
       context: ../
       dockerfile: docker/girder.Dockerfile
+    image: dandi_girder
     volumes:
-      - girder_assetstore:/home/assetstore
+      - dandi_girder_assetstore:/home/assetstore
     depends_on:
       - mongo
     ports:
@@ -21,6 +22,7 @@ services:
     build:
       context: ../
       dockerfile: docker/client.Dockerfile
+    image: dandi_client
     depends_on:
       - girder
     ports:
@@ -30,9 +32,10 @@ services:
     build:
       context: ../
       dockerfile: docker/provision.Dockerfile
+    image: dandi_provision
     depends_on:
       - client
 
 volumes:
-  mongo_db:
-  girder_assetstore:
+  dandi_girder_mongo_db:
+  dandi_girder_assetstore:


### PR DESCRIPTION
I have ran into the situation where I am trying multiple compose recipes,
and mongo is one of the popular ones. I also had girder ran from its own compose recipe.

Without consistent prefix for images and volumes it becomes hard(er) to select and remove some I no longer care about.  So I decided to add `dandi_` prefix to disambiguate.  Seems to work
and brings some structure:

    $> docker ps | grep dandi
    9c79b6581cdc        dandi_client        "nginx -g 'daemon of…"   14 minutes ago      Up 14 minutes       0.0.0.0:8092->80/tcp     docker_client_1
    83fa38732d9c        dandi_girder        "/home/provision/gir…"   14 minutes ago      Up 14 minutes       0.0.0.0:8091->8080/tcp   docker_girder_1

    $> docker images | grep dandi
    dandi_provision                         latest              04dcbd13b01d        14 minutes ago      930MB
    dandi_client                            latest              be88509b18c1        15 minutes ago      143MB
    dandi_girder                            latest              b5f249831189        16 minutes ago      1.43GB

    $> docker volume list | grep dandi
    local               docker_dandi_girder_assetstore
    local               docker_dandi_girder_mongo_db