### PR TITLE
Use lockfile, yarn, --frozen-lockfile

### DIFF
--- a/docker/client.Dockerfile
+++ b/docker/client.Dockerfile
@@ -1,8 +1,9 @@
 FROM node
 
 COPY web/package.json /client/package.json
+COPY web/yarn.lock /client/yarn.lock
 WORKDIR /client
-RUN npm install
+RUN yarn install --frozen-lockfile
 COPY web /client
 RUN yarn run build --mode docker
 


### PR DESCRIPTION
Noticed a discussion on this in another thread.

It's best not to mix yarn and npm.  You should also use `--frozen-lockfile` or `--pure-lockfile` when installing into a docker image.  https://github.com/yarnpkg/yarn/issues/4147