### PR TITLE
TEMP: changes I tried to make yarn/vue/webpack to behave... no luck yet

### DIFF
--- a/web/src/views/DandiMetaViewer.vue
+++ b/web/src/views/DandiMetaViewer.vue
@@ -91,7 +91,9 @@
                 </v-list-item>
                 <v-list-item v-if="details">
                   <v-list-item-content>
-                    <!-- Size: {{computedSize}}, Files: {{details.nItems}}, Folders: {{details.nFolders}} -->
+                    <!-- Size: {{computedSize}},
+                         Files: {{details.nItems}},
+                         Folders: {{details.nFolders}} -->
                     Files: {{details.nItems}}, Folders: {{details.nFolders}}
                   </v-list-item-content>
                 </v-list-item>

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -1,6 +1,7 @@
 process.env.VUE_APP_VERSION = process.env.COMMIT_REF;
 
 module.exports = {
+  parallel: false,
   lintOnSave: false,
   configureWebpack: {
     devtool: 'source-map',

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -2,7 +2,7 @@ process.env.VUE_APP_VERSION = process.env.COMMIT_REF;
 
 module.exports = {
   parallel: false,
-  lintOnSave: false,
+  lintOnSave: 'error',
   configureWebpack: {
     devtool: 'source-map',
   },

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,3 +1,4 @@
 module.exports = {
+    cache: false,
     parallelism: 1
 }

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    parallelism: 1
+}


### PR DESCRIPTION
in relation to #132 -- a collection of commits some of which might or not eventually could be adopted tuning configuration of the whole thing to make bloody client container build reliably

unfortunately "lintOnSave" is not doing anything really useful, like failing the whole thing if webpack at the end reports a "warning".  Here is what I see at the end of my run of `docker-compose build client`:

```shell
...
<s> [webpack.Progress] 66% building 614/656 modules 42 active /client/node_modules/@girder/components/node_modules/vuetify/lib/components/VTreeview/VTreeview.js
<s> [webpack.Progress] 66% building 615/656 modules 41 active /client/node_modules/@girder/components/node_modules/vuetify/lib/components/VTreeview/VTreeview.js
<s> [webpack.Progress] 66% building 616/656 modules 40 active /client/node_modules/@girder/components/node_modules/vuetify/lib/components/VTreeview/VTreeview.js
```
so `parallel` and `parallelism` options I have tried do no good (>1 active reported)

```
...
<s> [webpack.Progress] 95% emitting HtmlWebpackPlugin
<s> [webpack.Progress] 95% emitting CopyPlugin
<s> [webpack.Progress] 98% after emitting
<s> [webpack.Progress] 98% after emitting CopyPlugin
 WARNING  Compiled with 4 warnings10:57:38 PM

 warning  in ./src/views/Home.vue?vue&type=script&lang=js&

"export 'DataDetails' (imported as 'GirderDataDetails') was not found in '@girder/components/src/components'

 warning  in ./node_modules/@girder/components/src/components/DataDetails.vue?vue&type=script&lang=js&

"export 'dateFormatter' was not found in '../utils/mixins'

 warning  in ./node_modules/@girder/components/src/components/DataDetails.vue?vue&type=script&lang=js&

"export 'dateFormatter' was not found in '../utils/mixins'

 warning  in ./node_modules/@girder/components/src/components/DataDetails.vue?vue&type=script&lang=js&

"export 'usernameFormatter' was not found in '../utils/mixins'

<s> [webpack.Progress] 100% 

  File           Size                          Gzipped

  dist/app.js    7012.66 KiB                   1003.79 KiB

  Images and other types of assets omitted.

 DONE  Build complete. The dist directory is ready to be deployed.
 INFO  Check out deployment instructions at https://cli.vuejs.org/guide/deployment.html
      
Done in 30.99s.
Removing intermediate container 9a7d947a3828
 ---> 2eae4c6f1421
Step 8/10 : FROM nginx
 ---> 6678c7c2e56c
Step 9/10 : RUN rm -rf /usr/share/nginx/html/*
