### PR TITLE
BF: dandiset.yaml not dandidata.yaml

### DIFF
--- a/web/src/components/MetaEditor.vue
+++ b/web/src/components/MetaEditor.vue
@@ -197,7 +197,7 @@ export default {
       const blob = new Blob([this.output], { type: this.contentType });
 
       const extension = this.contentType.split('/')[1];
-      const filename = `dandidata.${extension}`;
+      const filename = `dandiset.${extension}`;
       const link = document.createElement('a');
 
       link.href = URL.createObjectURL(blob);


### PR DESCRIPTION
Although editor should be generic, ATM it is geared toward
"Dandiset Metadata" as v-card-title says, and AFAIK we do
not have it used for any other metadata editing.
Given that it should be safe to hardcode from dandidata.
to dandiset.

Closes #99