### PR TITLE
Load Sentry in development

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -12,13 +12,7 @@ Vue.use(Girder);
 
 Sentry.init({
   dsn: process.env.VUE_APP_SENTRY_DSN,
-  integrations: [
-    new Integrations.Vue({ 
-      Vue, 
-      attachProps: true,
-      logErrors: true 
-    }),
-  ],
+  integrations: [new Integrations.Vue({ Vue, logErrors: true })],
 });
 
 const apiRoot = process.env.VUE_APP_API_ROOT || 'http://localhost:8080/api/v1';

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -10,12 +10,16 @@ import store from './store';
 
 Vue.use(Girder);
 
-if (process.env.VUE_APP_SENTRY_DSN) {
-  Sentry.init({
-    dsn: process.env.VUE_APP_SENTRY_DSN,
-    integrations: [new Integrations.Vue({ Vue, logErrors: true })],
-  });
-}
+Sentry.init({
+  dsn: process.env.VUE_APP_SENTRY_DSN,
+  integrations: [
+    new Integrations.Vue({ 
+      Vue, 
+      attachProps: true,
+      logErrors: true 
+    }),
+  ],
+});
 
 const apiRoot = process.env.VUE_APP_API_ROOT || 'http://localhost:8080/api/v1';
 const girderRest = new RestClient({ apiRoot, setLocalCookie: true });


### PR DESCRIPTION
If a DSN (`process.env.VUE_APP_SENTRY_DSN`) is not set, Sentry will gracefully no-op, and errors will not be sent to Sentry.

By always loading Sentry, it ensures the development environment is closer to production.

~~Also, for more useful diagnosis, enable the `attachProps` option to the Sentry + Vue integration: https://docs.sentry.io/platforms/javascript/vue/~~