### PR TITLE
Start dandiset ID counter at 1

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -10,13 +10,13 @@ from .rest import DandiResource
 from .util import DANDISET_IDENTIFIER_COUNTER
 
 
-class GirderPlugin(GirderPlugin):
+class DandiArchivePlugin(GirderPlugin):
     DISPLAY_NAME = "DANDI Archive"
 
     def load(self, info):
         Setting().collection.update(
             {"key": DANDISET_IDENTIFIER_COUNTER},
-            {"$setOnInsert": {"value": 0}},
+            {"$setOnInsert": {"value": 1}},
             upsert=True,
         )
         search.addSearchMode("dandi", dandi_search_handler)

--- a/girder-dandi-archive/setup.py
+++ b/girder-dandi-archive/setup.py
@@ -38,6 +38,6 @@ setup(
     version="0.1.0",
     zip_safe=False,
     entry_points={
-        "girder.plugin": ["dandi_archive = girder_dandi_archive:GirderPlugin"]
+        "girder.plugin": ["dandi_archive = girder_dandi_archive:DandiArchivePlugin"]
     },
 )

--- a/girder-dandi-archive/tests/test_rest.py
+++ b/girder-dandi-archive/tests/test_rest.py
@@ -17,19 +17,19 @@ def draftsFolders(db):
         "red_herring_collection", reuseExisting=True
     )
     # A folder that matches dandiset metadata, but not in drafts collection.
-    red_herring_dandiset_000000_folder = Folder().createFolder(
+    red_herring_dandiset_000001_folder = Folder().createFolder(
         parent=red_herring_collection,
         parentType="collection",
-        name="000000",
+        name="000001",
         public=True,
     )
     meta = {
-        "dandiset": {"name": "red", "description": "herring", "identifier": "000000"}
+        "dandiset": {"name": "red", "description": "herring", "identifier": "000001"}
     }
-    Folder().setMetadata(red_herring_dandiset_000000_folder, meta)
+    Folder().setMetadata(red_herring_dandiset_000001_folder, meta)
     return_dict = {
         "red_herring_collection": red_herring_collection,
-        "red_herring_folder": red_herring_dandiset_000000_folder,
+        "red_herring_folder": red_herring_dandiset_000001_folder,
     }
     return_dict["drafts_collection"] = get_or_create_drafts_collection()
     yield return_dict
@@ -38,25 +38,6 @@ def draftsFolders(db):
 @pytest.mark.plugin("dandi_archive")
 def testCreateDandiset(server, draftsFolders, user):
     drafts_collection_id = str(draftsFolders["drafts_collection"]["_id"])
-
-    resp = server.request(
-        path="/dandi",
-        method="POST",
-        user=user,
-        params={
-            "name": "test dandiset 0 name",
-            "description": "test dandiset 0 description",
-        },
-    )
-    assertStatusOk(resp)
-    test_dandiset_0_folder = resp.json
-    test_dandiset_0_folder_meta = test_dandiset_0_folder["meta"]["dandiset"]
-
-    assert drafts_collection_id == test_dandiset_0_folder["parentId"]
-    assert "000000" == test_dandiset_0_folder["name"]
-    assert "000000" == test_dandiset_0_folder_meta["identifier"]
-    assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
-    assert "test dandiset 0 description" == test_dandiset_0_folder_meta["description"]
 
     resp = server.request(
         path="/dandi",
@@ -77,6 +58,25 @@ def testCreateDandiset(server, draftsFolders, user):
     assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
     assert "test dandiset 1 description" == test_dandiset_1_folder_meta["description"]
 
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={
+            "name": "test dandiset 2 name",
+            "description": "test dandiset 2 description",
+        },
+    )
+    assertStatusOk(resp)
+    test_dandiset_2_folder = resp.json
+    test_dandiset_2_folder_meta = test_dandiset_2_folder["meta"]["dandiset"]
+
+    assert drafts_collection_id == test_dandiset_2_folder["parentId"]
+    assert "000002" == test_dandiset_2_folder["name"]
+    assert "000002" == test_dandiset_2_folder_meta["identifier"]
+    assert "test dandiset 2 name" == test_dandiset_2_folder_meta["name"]
+    assert "test dandiset 2 description" == test_dandiset_2_folder_meta["description"]
+
 
 @pytest.mark.plugin("dandi_archive")
 def testGetDandiset(server, draftsFolders, user, capsys):
@@ -84,7 +84,7 @@ def testGetDandiset(server, draftsFolders, user, capsys):
 
     # Ensure we don't find any before creation, in the wrong parent.
     resp = server.request(
-        path="/dandi", method="GET", user=user, params={"identifier": "000000"}
+        path="/dandi", method="GET", user=user, params={"identifier": "000001"}
     )
     assertStatus(resp, 400)
 
@@ -94,22 +94,22 @@ def testGetDandiset(server, draftsFolders, user, capsys):
         method="POST",
         user=user,
         params={
-            "name": "test dandiset 0 name",
-            "description": "test dandiset 0 description",
+            "name": "test dandiset 1 name",
+            "description": "test dandiset 1 description",
         },
     )
     assertStatusOk(resp)
-    assert "000000" == resp.json["meta"]["dandiset"]["identifier"]
+    assert "000001" == resp.json["meta"]["dandiset"]["identifier"]
 
     # Ensure we can retrieve the Dandiset.
     resp = server.request(
-        path="/dandi", method="GET", user=user, params={"identifier": "000000"}
+        path="/dandi", method="GET", user=user, params={"identifier": "000001"}
     )
     assertStatusOk(resp)
-    test_dandiset_0_folder = resp.json
-    test_dandiset_0_folder_meta = test_dandiset_0_folder["meta"]["dandiset"]
-    assert drafts_collection_id == test_dandiset_0_folder["parentId"]
-    assert "000000" == test_dandiset_0_folder["name"]
-    assert "000000" == test_dandiset_0_folder_meta["identifier"]
-    assert "test dandiset 0 name" == test_dandiset_0_folder_meta["name"]
-    assert "test dandiset 0 description" == test_dandiset_0_folder_meta["description"]
+    test_dandiset_1_folder = resp.json
+    test_dandiset_1_folder_meta = test_dandiset_1_folder["meta"]["dandiset"]
+    assert drafts_collection_id == test_dandiset_1_folder["parentId"]
+    assert "000001" == test_dandiset_1_folder["name"]
+    assert "000001" == test_dandiset_1_folder_meta["identifier"]
+    assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
+    assert "test dandiset 1 description" == test_dandiset_1_folder_meta["description"]


### PR DESCRIPTION
The dandiset was originally set to start at 0 when the first collection
was registered. Change that default to 1.

The name of the DANDI plugin class was `GirderPlugin` for some reason,
which conflicts with the original `GirderPlugin` superclass. Change
that to `DandiArchivePlugin` and update the `entry_point` in setup.py.

I tested this by stopping Mongo, deleting everything from the DB directory, restarting Mongo, starting Girder, then registering a dataset.

After changing the plugin name, I had to rerun `pip install -e .` to reregister setup.py so the plugin would launch.