### PR TITLE
#126 Restructure test_rest.py tests and add test utilities

### DIFF
--- a/girder-dandi-archive/tests/test_rest.py
+++ b/girder-dandi-archive/tests/test_rest.py
@@ -7,12 +7,16 @@ from girder.models.folder import Folder
 
 from pytest_girder.assertions import assertStatus, assertStatusOk
 
+pytestmark = pytest.mark.plugin("dandi_archive")
 
-# TODO: This fixture and these tests are not well structured and hard to maintain.
-# They currently work correctly in terms of the application code that they test,
-# but they should be rewritten and not followed as an example.
+NAME_1 = "test dandiset 1 name"
+DESCRIPTION_1 = "test dandiset 1 description"
+NAME_2 = "test dandiset 2 name"
+DESCRIPTION_2 = "test dandiset 2 description"
+
+
 @pytest.fixture
-def draftsFolders(db):
+def drafts_folders(db):
     red_herring_collection = Collection().createCollection(
         "red_herring_collection", reuseExisting=True
     )
@@ -35,81 +39,189 @@ def draftsFolders(db):
     yield return_dict
 
 
-@pytest.mark.plugin("dandi_archive")
-def testCreateDandiset(server, draftsFolders, user):
-    drafts_collection_id = str(draftsFolders["drafts_collection"]["_id"])
+@pytest.fixture
+def dandiset_1(server, drafts_folders, user):
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={"name": NAME_1, "description": DESCRIPTION_1},
+    )
+    assertStatusOk(resp)
+    yield resp.json
+
+
+@pytest.fixture
+def dandiset_2(server, drafts_folders, user):
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={"name": NAME_2, "description": DESCRIPTION_2},
+    )
+    assertStatusOk(resp)
+    yield resp.json
+
+
+def test_create_dandiset(server, drafts_folders, user):
+    drafts_collection_id = str(drafts_folders["drafts_collection"]["_id"])
+    user_id = str(user["_id"])
 
     resp = server.request(
         path="/dandi",
         method="POST",
         user=user,
-        params={
-            "name": "test dandiset 1 name",
-            "description": "test dandiset 1 description",
-        },
+        params={"name": NAME_1, "description": DESCRIPTION_1},
     )
     assertStatusOk(resp)
-    test_dandiset_1_folder = resp.json
-    test_dandiset_1_folder_meta = test_dandiset_1_folder["meta"]["dandiset"]
 
-    assert drafts_collection_id == test_dandiset_1_folder["parentId"]
-    assert "000001" == test_dandiset_1_folder["name"]
-    assert "000001" == test_dandiset_1_folder_meta["identifier"]
-    assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
-    assert "test dandiset 1 description" == test_dandiset_1_folder_meta["description"]
+    assert resp.json["access"] == {
+        "groups": [],
+        "users": [{"flags": [], "id": user_id, "level": 2}],
+    }
+    assert resp.json["baseParentId"] == drafts_collection_id
+    assert resp.json["baseParentType"] == "collection"
+    assert resp.json["creatorId"] == user_id
+    assert resp.json["description"] == ""
+    assert resp.json["lowerName"] == "000001"
+    assert resp.json["meta"] == {
+        "dandiset": {
+            "identifier": "000001",
+            "name": NAME_1,
+            "description": DESCRIPTION_1,
+        }
+    }
+    assert resp.json["name"] == "000001"
+    assert resp.json["parentCollection"] == "collection"
+    assert resp.json["parentId"] == drafts_collection_id
+    assert resp.json["public"] is True
+    assert resp.json["size"] == 0
+
+
+def test_create_two_dandisets(server, drafts_folders, user, dandiset_1):
+    drafts_collection_id = str(drafts_folders["drafts_collection"]["_id"])
+    user_id = str(user["_id"])
 
     resp = server.request(
         path="/dandi",
         method="POST",
         user=user,
-        params={
-            "name": "test dandiset 2 name",
-            "description": "test dandiset 2 description",
-        },
+        params={"name": NAME_2, "description": DESCRIPTION_2},
     )
     assertStatusOk(resp)
-    test_dandiset_2_folder = resp.json
-    test_dandiset_2_folder_meta = test_dandiset_2_folder["meta"]["dandiset"]
 
-    assert drafts_collection_id == test_dandiset_2_folder["parentId"]
-    assert "000002" == test_dandiset_2_folder["name"]
-    assert "000002" == test_dandiset_2_folder_meta["identifier"]
-    assert "test dandiset 2 name" == test_dandiset_2_folder_meta["name"]
-    assert "test dandiset 2 description" == test_dandiset_2_folder_meta["description"]
+    assert resp.json["access"] == {
+        "groups": [],
+        "users": [{"flags": [], "id": user_id, "level": 2}],
+    }
+    assert resp.json["baseParentId"] == drafts_collection_id
+    assert resp.json["baseParentType"] == "collection"
+    assert resp.json["creatorId"] == user_id
+    assert resp.json["description"] == ""
+    assert resp.json["lowerName"] == "000002"
+    assert resp.json["meta"] == {
+        "dandiset": {
+            "identifier": "000002",
+            "name": NAME_2,
+            "description": DESCRIPTION_2,
+        }
+    }
+    assert resp.json["name"] == "000002"
+    assert resp.json["parentCollection"] == "collection"
+    assert resp.json["parentId"] == drafts_collection_id
+    assert resp.json["public"] is True
+    assert resp.json["size"] == 0
 
 
-@pytest.mark.plugin("dandi_archive")
-def testGetDandiset(server, draftsFolders, user, capsys):
-    drafts_collection_id = str(draftsFolders["drafts_collection"]["_id"])
+def test_create_dandiset_no_name(server, drafts_folders, user):
+    resp = server.request(
+        path="/dandi", method="POST", user=user, params={"description": DESCRIPTION_1},
+    )
+    assertStatus(resp, 400)
 
-    # Ensure we don't find any before creation, in the wrong parent.
+
+def test_create_dandiset_no_description(server, drafts_folders, user):
+    resp = server.request(
+        path="/dandi", method="POST", user=user, params={"name": NAME_1},
+    )
+    assertStatus(resp, 400)
+
+
+def test_create_dandiset_empty_name(server, drafts_folders, user):
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={"name": "", "description": DESCRIPTION_1},
+    )
+    assertStatus(resp, 400)
+
+
+def test_create_dandiset_empty_description(server, drafts_folders, user):
+    resp = server.request(
+        path="/dandi",
+        method="POST",
+        user=user,
+        params={"name": NAME_1, "description": ""},
+    )
+    assertStatus(resp, 400)
+
+
+def test_get_dandiset(server, drafts_folders, user, dandiset_1):
+    identifier = dandiset_1["name"]
+    drafts_collection_id = str(drafts_folders["drafts_collection"]["_id"])
+    user_id = str(user["_id"])
+
+    # Ensure we can retrieve the Dandiset.
+    resp = server.request(
+        path="/dandi", method="GET", user=user, params={"identifier": identifier}
+    )
+    assertStatusOk(resp)
+
+    assert resp.json["access"] == {
+        "groups": [],
+        "users": [{"flags": [], "id": user_id, "level": 2}],
+    }
+    assert resp.json["baseParentId"] == drafts_collection_id
+    assert resp.json["baseParentType"] == "collection"
+    assert resp.json["creatorId"] == user_id
+    assert resp.json["description"] == ""
+    assert resp.json["lowerName"] == "000001"
+    assert resp.json["meta"] == {
+        "dandiset": {
+            "identifier": "000001",
+            "name": NAME_1,
+            "description": DESCRIPTION_1,
+        }
+    }
+    assert resp.json["name"] == "000001"
+    assert resp.json["parentCollection"] == "collection"
+    assert resp.json["parentId"] == drafts_collection_id
+    assert resp.json["public"] is True
+    assert resp.json["size"] == 0
+
+
+def test_get_dandiset_does_not_exist(server, drafts_folders, user):
     resp = server.request(
         path="/dandi", method="GET", user=user, params={"identifier": "000001"}
     )
     assertStatus(resp, 400)
 
-    # Create a Dandiset.
-    resp = server.request(
-        path="/dandi",
-        method="POST",
-        user=user,
-        params={
-            "name": "test dandiset 1 name",
-            "description": "test dandiset 1 description",
-        },
-    )
-    assertStatusOk(resp)
-    assert "000001" == resp.json["meta"]["dandiset"]["identifier"]
 
-    # Ensure we can retrieve the Dandiset.
+def test_get_dandiset_no_identifier(server, drafts_folders, user, dandiset_1):
+    resp = server.request(path="/dandi", method="GET", user=user, params={})
+    assertStatus(resp, 400)
+
+
+def test_get_dandiset_empty_identifier(server, drafts_folders, user, dandiset_1):
     resp = server.request(
-        path="/dandi", method="GET", user=user, params={"identifier": "000001"}
+        path="/dandi", method="GET", user=user, params={"identifier": ""}
     )
-    assertStatusOk(resp)
-    test_dandiset_1_folder = resp.json
-    test_dandiset_1_folder_meta = test_dandiset_1_folder["meta"]["dandiset"]
-    assert drafts_collection_id == test_dandiset_1_folder["parentId"]
-    assert "000001" == test_dandiset_1_folder["name"]
-    assert "000001" == test_dandiset_1_folder_meta["identifier"]
-    assert "test dandiset 1 name" == test_dandiset_1_folder_meta["name"]
-    assert "test dandiset 1 description" == test_dandiset_1_folder_meta["description"]
+    assertStatus(resp, 400)
+
+
+def test_get_dandiset_invalid_identifier(server, drafts_folders, user, dandiset_1):
+    resp = server.request(
+        path="/dandi", method="GET", user=user, params={"identifier": "1"}
+    )
+    assertStatus(resp, 400)


### PR DESCRIPTION
Restructure the slightly malformed test_rest.py tests into smaller, more
singleminded tests. Add new tests to cover negative code paths.

To make asserting large, complex JSON responses easier, I added a
utility, `substitute.py`, which enables "vague" assertions about objects
that do not have explicitly expected values, but do have some implicit
state. An instance of the `Timestamp` class is used to represent any
reasonably well-formatted timestamp in a JSON response. I do not think
that this utility belongs as is, but I want to generate some discussion
on it.

I've included a test file to demonstrate how `substitute.py` works. I also included both the original asserts and the new, substituty asserts in `test_rest.py` so the two styles can be compared. Any thoughts are welcome.

Fixes #126 