### PR TITLE
Reduce dandicli API key scope

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -1,6 +1,7 @@
 from girder.api import access
 from girder.api.rest import Resource
 from girder.api.describe import describeRoute, Description
+from girder.constants import TokenScope
 from girder.models.setting import Setting
 from girder.models.folder import Folder
 from girder.exceptions import RestException
@@ -21,7 +22,7 @@ class DandiResource(Resource):
         self.route("GET", (), self.get_dandiset)
         self.route("POST", (), self.create_dandiset)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @describeRoute(
         Description("Create Dandiset")
         .param("name", "Name of the Dandiset.")

--- a/web/src/store.js
+++ b/web/src/store.js
@@ -73,7 +73,7 @@ export default new Vuex.Store({
         const { status: createStatus, data: { key } } = await state.girderRest.post('api_key', null, {
           params: {
             name: 'dandicli',
-            scope: null,
+            scope: JSON.stringify(['core.data.read', 'core.data.write']),
             tokenDuration: 30,
             active: true,
           },


### PR DESCRIPTION
The dandicli API key currently has the default scope, which is
everything. It should use the minimum scope required, `core.data.read
core.data.write`.

This also involves specifying the correct scope in the
create_dandiset endpoint. All other endpoints are currently public.

I tested the new, reduced scope `dandicli` API key in the web UI and in the python CLI, and I was able to create new dandisets in both.

I did not add any regression tests because the `dandicli` API key isn't defined on the server side. It is instead created as necessary by the web UI. If we ever decide to initialize that API key on the server then it would definitely be appropriate to find a way to parameterize `test_rest.py` to use both the user and the `dandicli` token.

Fixes #156 