### PR TITLE
Move list dandisets and get dandiset endpoints to be idiomatic

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -19,8 +19,8 @@ class DandiResource(Resource):
         super(DandiResource, self).__init__()
 
         self.resourceName = "dandi"
-        self.route("GET", (), self.get_dandiset)
-        self.route("GET", ("list",), self.list_dandisets)
+        self.route("GET", (":identifier",), self.get_dandiset)
+        self.route("GET", (), self.list_dandisets)
         self.route("POST", (), self.create_dandiset)
 
     @access.user(scope=TokenScope.DATA_WRITE)
@@ -63,13 +63,11 @@ class DandiResource(Resource):
 
     @access.public
     @describeRoute(
-        Description("Get Dandiset").param("identifier", "Dandiset Identifier")
+        Description("Get Dandiset").param(
+            "identifier", "Dandiset Identifier", paramType="path"
+        )
     )
-    def get_dandiset(self, params):
-        if "identifier" not in params:
-            raise RestException("identifier required.")
-
-        identifier = params["identifier"]
+    def get_dandiset(self, identifier, params):
 
         if not identifier:
             raise RestException("identifier must not be empty.")

--- a/girder-dandi-archive/tests/rest/test_get_dandiset.py
+++ b/girder-dandi-archive/tests/rest/test_get_dandiset.py
@@ -3,41 +3,22 @@ from pytest_girder.assertions import assertStatus, assertStatusOk
 from rest_utils import assert_dandisets_are_equal
 
 pytestmark = pytest.mark.plugin("dandi_archive")
-path = "/dandi"
 
 
 def test_get_dandiset(server, request_auth, dandiset_1):
     identifier = dandiset_1["name"]
 
-    resp = server.request(
-        path=path, method="GET", params={"identifier": identifier}, **request_auth
-    )
+    resp = server.request(path="/dandi/" + identifier, method="GET", **request_auth,)
     assertStatusOk(resp)
 
     assert_dandisets_are_equal(dandiset_1, resp.json)
 
 
 def test_get_dandiset_does_not_exist(server, request_auth):
-    resp = server.request(
-        path=path, method="GET", params={"identifier": "000001"}, **request_auth
-    )
-    assertStatus(resp, 400)
-
-
-def test_get_dandiset_no_identifier(server, request_auth, dandiset_1):
-    resp = server.request(path=path, method="GET", params={}, **request_auth)
-    assertStatus(resp, 400)
-
-
-def test_get_dandiset_empty_identifier(server, request_auth, dandiset_1):
-    resp = server.request(
-        path=path, method="GET", params={"identifier": ""}, **request_auth,
-    )
+    resp = server.request(path="/dandi/000001", method="GET", **request_auth)
     assertStatus(resp, 400)
 
 
 def test_get_dandiset_invalid_identifier(server, request_auth, dandiset_1):
-    resp = server.request(
-        path=path, method="GET", params={"identifier": "1"}, **request_auth
-    )
+    resp = server.request(path="/dandi/x", method="GET", **request_auth)
     assertStatus(resp, 400)

--- a/girder-dandi-archive/tests/rest/test_get_dandiset.py
+++ b/girder-dandi-archive/tests/rest/test_get_dandiset.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.plugin("dandi_archive")
 def test_get_dandiset(server, request_auth, dandiset_1):
     identifier = dandiset_1["name"]
 
-    resp = server.request(path="/dandi/" + identifier, method="GET", **request_auth,)
+    resp = server.request(path=f"/dandi/{identifier}", method="GET", **request_auth,)
     assertStatusOk(resp)
 
     assert_dandisets_are_equal(dandiset_1, resp.json)

--- a/girder-dandi-archive/tests/rest/test_list_dandisets.py
+++ b/girder-dandi-archive/tests/rest/test_list_dandisets.py
@@ -3,7 +3,7 @@ from pytest_girder.assertions import assertStatusOk
 from rest_utils import assert_dandisets_are_equal
 
 pytestmark = pytest.mark.plugin("dandi_archive")
-path = "/dandi/list"
+path = "/dandi"
 
 
 def test_list_dandisets(server, request_auth, dandiset_1, dandiset_2):


### PR DESCRIPTION
Move list dandisets to `/api/v1/dandi`
Move get dandiset to `/api/v1/dandi/<dandiset_id>`

Waiting on approval from @yarikoptic to verify that this change will not break anything in the CLI.

Fixes #193 