### PR TITLE
Add stats enpoint

### DIFF
--- a/girder-dandi-archive/tests/rest/test_stats.py
+++ b/girder-dandi-archive/tests/rest/test_stats.py
@@ -37,13 +37,13 @@ def test_stats_user(server, user):
     } == resp.json
 
 
-def test_stats_draft(server, user, dandiset_1):
+def test_stats_draft(server, dandiset_1):
     resp = server.request(path=path, method="GET")
     assertStatusOk(resp)
     assert {
         "draft_count": 1,
         "published_count": 0,
-        "user_count": 2,  # one admin user, one normal user
+        "user_count": 2,  # one admin user, one normal user, required by dandiset_1
         "species_count": 0,
         "subject_count": 0,
         "cell_count": 0,
@@ -51,7 +51,7 @@ def test_stats_draft(server, user, dandiset_1):
     } == resp.json
 
 
-def test_stats_species(server, user, dandiset_1):
+def test_stats_species(server, dandiset_1):
     dandiset_1["meta"]["dandiset"]["organism"] = [{"species": "Homo Sapiens"}]
     Folder().setMetadata(dandiset_1, dandiset_1["meta"])
 
@@ -60,7 +60,7 @@ def test_stats_species(server, user, dandiset_1):
     assert {
         "draft_count": 1,
         "published_count": 0,
-        "user_count": 2,  # one admin user, one normal user
+        "user_count": 2,  # one admin user, one normal user, required by dandiset_1
         "species_count": 1,
         "subject_count": 0,
         "cell_count": 0,
@@ -68,7 +68,7 @@ def test_stats_species(server, user, dandiset_1):
     } == resp.json
 
 
-def test_stats_two_species(server, user, dandiset_1):
+def test_stats_two_species(server, dandiset_1):
     dandiset_1["meta"]["dandiset"]["organism"] = [
         {"species": "Homo Sapiens"},
         {"species": "Homo Erectus"},
@@ -80,7 +80,7 @@ def test_stats_two_species(server, user, dandiset_1):
     assert {
         "draft_count": 1,
         "published_count": 0,
-        "user_count": 2,  # one admin user, one normal user
+        "user_count": 2,  # one admin user, one normal user, required by dandiset_1
         "species_count": 2,
         "subject_count": 0,
         "cell_count": 0,
@@ -88,7 +88,7 @@ def test_stats_two_species(server, user, dandiset_1):
     } == resp.json
 
 
-def test_stats_subjects(server, user, dandiset_1):
+def test_stats_subjects(server, dandiset_1):
 
     subject_count = 7
 
@@ -100,7 +100,7 @@ def test_stats_subjects(server, user, dandiset_1):
     assert {
         "draft_count": 1,
         "published_count": 0,
-        "user_count": 2,  # one admin user, one normal user
+        "user_count": 2,  # one admin user, one normal user, required by dandiset_1
         "species_count": 0,
         "subject_count": subject_count,
         "cell_count": 0,
@@ -108,7 +108,7 @@ def test_stats_subjects(server, user, dandiset_1):
     } == resp.json
 
 
-def test_stats_cells(server, user, dandiset_1):
+def test_stats_cells(server, dandiset_1):
 
     cell_count = 11
 
@@ -120,7 +120,7 @@ def test_stats_cells(server, user, dandiset_1):
     assert {
         "draft_count": 1,
         "published_count": 0,
-        "user_count": 2,  # one admin user, one normal user
+        "user_count": 2,  # one admin user, one normal user, required by dandiset_1
         "species_count": 0,
         "subject_count": 0,
         "cell_count": cell_count,
@@ -128,7 +128,7 @@ def test_stats_cells(server, user, dandiset_1):
     } == resp.json
 
 
-def test_stats_size(server, fsAssetstore, user, dandiset_1):
+def test_stats_size(server, fsAssetstore, dandiset_1):
     file_contents = "Hello World!"
     upload = Upload().createUpload(
         user=user,
@@ -144,7 +144,7 @@ def test_stats_size(server, fsAssetstore, user, dandiset_1):
     assert {
         "draft_count": 1,
         "published_count": 0,
-        "user_count": 2,  # one admin user, one normal user
+        "user_count": 2,  # one admin user, one normal user, required by dandiset_1
         "species_count": 0,
         "subject_count": 0,
         "cell_count": 0,

--- a/girder-dandi-archive/tests/rest/test_stats.py
+++ b/girder-dandi-archive/tests/rest/test_stats.py
@@ -1,0 +1,152 @@
+import pytest
+
+from girder.models.folder import Folder
+from girder.models.upload import Upload
+
+from pytest_girder.assertions import assertStatusOk
+
+pytestmark = pytest.mark.plugin("dandi_archive")
+path = "/dandi/stats"
+
+
+def test_stats_zero(server):
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 0,
+        "published_count": 0,
+        "user_count": 0,
+        "species_count": 0,
+        "subject_count": 0,
+        "cell_count": 0,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_user(server, user):
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 0,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 0,
+        "subject_count": 0,
+        "cell_count": 0,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_draft(server, user, dandiset_1):
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 1,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 0,
+        "subject_count": 0,
+        "cell_count": 0,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_species(server, user, dandiset_1):
+    dandiset_1["meta"]["dandiset"]["organism"] = [{"species": "Homo Sapiens"}]
+    Folder().setMetadata(dandiset_1, dandiset_1["meta"])
+
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 1,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 1,
+        "subject_count": 0,
+        "cell_count": 0,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_two_species(server, user, dandiset_1):
+    dandiset_1["meta"]["dandiset"]["organism"] = [
+        {"species": "Homo Sapiens"},
+        {"species": "Homo Erectus"},
+    ]
+    Folder().setMetadata(dandiset_1, dandiset_1["meta"])
+
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 1,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 2,
+        "subject_count": 0,
+        "cell_count": 0,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_subjects(server, user, dandiset_1):
+
+    subject_count = 7
+
+    dandiset_1["meta"]["dandiset"]["number_of_subjects"] = subject_count
+    Folder().setMetadata(dandiset_1, dandiset_1["meta"])
+
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 1,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 0,
+        "subject_count": subject_count,
+        "cell_count": 0,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_cells(server, user, dandiset_1):
+
+    cell_count = 11
+
+    dandiset_1["meta"]["dandiset"]["number_of_cells"] = cell_count
+    Folder().setMetadata(dandiset_1, dandiset_1["meta"])
+
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 1,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 0,
+        "subject_count": 0,
+        "cell_count": cell_count,
+        "size": 0,
+    } == resp.json
+
+
+def test_stats_size(server, fsAssetstore, user, dandiset_1):
+    file_contents = "Hello World!"
+    upload = Upload().createUpload(
+        user=user,
+        name="helloworld.txt",
+        parentType="folder",
+        parent=dandiset_1,
+        size=len(file_contents),
+    )
+    Upload().handleChunk(upload, file_contents)
+
+    resp = server.request(path=path, method="GET")
+    assertStatusOk(resp)
+    assert {
+        "draft_count": 1,
+        "published_count": 0,
+        "user_count": 2,  # one admin user, one normal user
+        "species_count": 0,
+        "subject_count": 0,
+        "cell_count": 0,
+        "size": len(file_contents),
+    } == resp.json


### PR DESCRIPTION
Add an endpoint that returns global dandiset stats. Fields include:

* Number of draft dandisets
* Number of published dandisets (currently always 0)
* Number of users
* Number of unique species
* Number of subjects
* Number of cells

Because of how weird the Mongo queries turned out to be I did some benchmarking and on my machine, the requests would stay <1s for up to 100,000 dandisets, which I think is reasonable for the near future.

Fixes #179 