### PR TITLE
Fix girder store module access bug

### DIFF
--- a/web/src/main.js
+++ b/web/src/main.js
@@ -17,7 +17,7 @@ Sentry.init({
 
 const apiRoot = process.env.VUE_APP_API_ROOT || 'http://localhost:8080/api/v1';
 const girderRest = new RestClient({ apiRoot, setLocalCookie: true });
-store.commit('setGirderRest', girderRest);
+store.commit('girder/setGirderRest', girderRest);
 sync(store, router);
 
 girderRest.fetchUser().then(() => {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -255,7 +255,7 @@ export default {
       async handler(value) {
         if (!this.selected || !this.meta.length) {
           const resp = await this.girderRest.get(`folder/${value}`);
-          this.$store.commit('setSelected', [resp.data]);
+          this.$store.commit('girder/setSelected', [resp.data]);
         }
       },
     },


### PR DESCRIPTION
When setting up the girder store module, the calls to `store.commit()`
were not updated to target the module instead of the global namespace.
Fix that by prepending `"girder/"` to the argument.
