### PR TITLE
Move girderRest out of store, into own file

### DIFF
--- a/web/src/components/DandiAppBar.vue
+++ b/web/src/components/DandiAppBar.vue
@@ -207,10 +207,11 @@
 </template>
 
 <script>
-import { mapActions, mapGetters, mapState } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 import { Search as GirderSearch, Authentication as GirderAuth } from '@girder/components/src/components';
 
 import { dandiUrl } from '@/utils';
+import girderRest, { loggedIn, user } from '@/rest';
 
 export default {
   components: { GirderSearch, GirderAuth },
@@ -221,11 +222,12 @@ export default {
     regdialog: false,
   }),
   computed: {
+    loggedIn,
+    user,
     saveDisabled() {
       return !(this.name && this.description);
     },
-    ...mapGetters('girder', ['loggedIn', 'user']),
-    ...mapState('girder', ['apiKey', 'girderRest']),
+    ...mapState('girder', ['apiKey']),
     version() {
       return process.env.VUE_APP_VERSION;
     },
@@ -256,7 +258,7 @@ export default {
     },
     async register_dandiset() {
       const { name, description } = this;
-      const { status, data } = await this.girderRest.post('dandi', null, { params: { name, description } });
+      const { status, data } = await girderRest.post('dandi', null, { params: { name, description } });
 
       if (status === 200) {
         this.name = '';

--- a/web/src/components/MetaEditor.vue
+++ b/web/src/components/MetaEditor.vue
@@ -127,6 +127,7 @@ import jsYaml from 'js-yaml';
 import Ajv from 'ajv';
 
 import MetaNode from '@/components/MetaNode.vue';
+import girderRest from '@/rest';
 
 const ajv = new Ajv({ allErrors: true });
 
@@ -174,8 +175,7 @@ export default {
       return this.yamlOutput ? jsYaml.dump(this.meta) : JSON.stringify(this.meta, null, 2);
     },
     ...mapState('girder', {
-      girderRest: 'girderRest',
-      id: (state) => state.selected[0]._id,
+      id: state => state.selected[0]._id,
     }),
   },
   watch: {
@@ -196,7 +196,7 @@ export default {
       this.$emit('close');
     },
     async save() {
-      const { status, data } = await this.girderRest.put(`folder/${this.id}/metadata`, { dandiset: this.meta });
+      const { status, data } = await girderRest.put(`folder/${this.id}/metadata`, { dandiset: this.meta });
 
       if (status === 200) {
         this.setSelected([data]);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -1,12 +1,13 @@
 import Vue from 'vue';
 import { sync } from 'vuex-router-sync';
-import Girder, { RestClient, vuetify } from '@girder/components/src';
+import Girder, { vuetify } from '@girder/components/src';
 import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
 
 import App from '@/App.vue';
 import router from '@/router';
 import store from '@/store';
+import girderRest from '@/rest';
 
 Vue.use(Girder);
 
@@ -15,16 +16,13 @@ Sentry.init({
   integrations: [new Integrations.Vue({ Vue, logErrors: true })],
 });
 
-const apiRoot = process.env.VUE_APP_API_ROOT || 'http://localhost:8080/api/v1';
-const girderRest = new RestClient({ apiRoot, setLocalCookie: true });
-store.commit('girder/setGirderRest', girderRest);
 sync(store, router);
 
 girderRest.fetchUser().then(() => {
   new Vue({
     provide: { girderRest },
     router,
-    render: (h) => h(App),
+    render: h => h(App),
     store,
     vuetify,
   }).$mount('#app');

--- a/web/src/rest.js
+++ b/web/src/rest.js
@@ -1,0 +1,14 @@
+
+import { RestClient } from '@girder/components/src';
+
+const apiRoot = process.env.VUE_APP_API_ROOT || 'http://localhost:8080/api/v1';
+const girderRest = new RestClient({ apiRoot, setLocalCookie: true });
+
+const loggedIn = () => !!girderRest.user;
+const user = () => girderRest.user;
+
+export {
+  loggedIn,
+  user,
+};
+export default girderRest;

--- a/web/src/store/girder.js
+++ b/web/src/store/girder.js
@@ -1,32 +1,26 @@
 import Vue from 'vue';
 
+import girderRest from '@/rest';
+
 export default {
   namespaced: true,
   state: {
     apiKey: null,
-    girderRest: null,
     browseLocation: null,
     selected: [],
-  },
-  getters: {
-    loggedIn: (state) => !!state.girderRest.user,
-    user: (state) => state.girderRest.user,
   },
   mutations: {
     setApiKey(state, apiKey) {
       state.apiKey = apiKey;
-    },
-    setGirderRest(state, gr) {
-      state.girderRest = gr;
     },
     setSelected(state, selected) {
       state.selected = selected;
     },
   },
   actions: {
-    async reloadApiKey({ state, commit, getters }) {
-      const { user } = getters;
-      const { status, data } = await state.girderRest.get(
+    async reloadApiKey({ commit }) {
+      const { user } = girderRest;
+      const { status, data } = await girderRest.get(
         'api_key', {
           params: {
             userId: user._id,
@@ -37,16 +31,16 @@ export default {
         },
       );
 
-      const [dandiKey] = data.filter((key) => key.name === 'dandicli');
+      const [dandiKey] = data.filter(key => key.name === 'dandicli');
       if (status === 200 && dandiKey) {
         // send the key id to "PUT" endpoint for updating
-        const { data: { key } } = await state.girderRest.put(`api_key/${dandiKey._id}`);
+        const { data: { key } } = await girderRest.put(`api_key/${dandiKey._id}`);
         commit('setApiKey', key);
       }
     },
-    async fetchApiKey({ state, commit, getters }) {
-      const { user } = getters;
-      const { status, data } = await state.girderRest.get(
+    async fetchApiKey({ commit }) {
+      const { user } = girderRest;
+      const { status, data } = await girderRest.get(
         'api_key', {
           params: {
             userId: user._id,
@@ -57,7 +51,7 @@ export default {
         },
       );
 
-      const [dandiKey] = data.filter((key) => key.name === 'dandicli');
+      const [dandiKey] = data.filter(key => key.name === 'dandicli');
       if (status === 200 && dandiKey) {
         // if there is an existing api key
 
@@ -65,7 +59,7 @@ export default {
         commit('setApiKey', dandiKey.key);
       } else {
         // create a key using "POST" endpoint
-        const { status: createStatus, data: { key } } = await state.girderRest.post('api_key', null, {
+        const { status: createStatus, data: { key } } = await girderRest.post('api_key', null, {
           params: {
             name: 'dandicli',
             scope: null,
@@ -79,11 +73,11 @@ export default {
         }
       }
     },
-    async selectSearchResult({ state, commit }, result) {
+    async selectSearchResult({ commit }, result) {
       commit('setSelected', []);
 
       if (result._modelType === 'item') {
-        const resp = await state.girderRest.get(`folder/${result.folderId}`);
+        const resp = await girderRest.get(`folder/${result.folderId}`);
         commit('setBrowseLocation', resp.data);
         // Because setting the location is going to trigger the DataBrowser to
         // set its selected value to [], which due to two-way binding also propagates back
@@ -95,8 +89,8 @@ export default {
         commit('setBrowseLocation', result);
       }
     },
-    async logout({ state }) {
-      await state.girderRest.logout();
+    async logout() {
+      await girderRest.logout();
     },
   },
 };


### PR DESCRIPTION
This moves the `RestClient` object out of the state, and into `rest.js`, along with a couple of getters associated with it. These getters are now functions, and can be imported directly.