### PR TITLE
Add Roboto font

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -18,6 +18,8 @@ export default {
 </script>
 
 <style scoped>
+@import url("https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900");
+
 .dandi-app {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
The default Vuetify font, Roboto, was not included, so the default
sans-serif system font was being used instead.