### PR TITLE
Temporarily remove stats from DandisetList component

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -14,7 +14,7 @@
           no-gutters
           align="center"
         >
-          <v-col cols="10">
+          <v-col cols="12">
             <v-list-item-content>
               <v-list-item-title>
                 <template v-if="item.meta.dandiset.version">
@@ -44,7 +44,8 @@
               </v-list-item-subtitle>
             </v-list-item-content>
           </v-col>
-          <v-col cols="1">
+          <!-- TODO: Uncomment this once backend detail issue is sorted -->
+          <!-- <v-col cols="1">
             <v-icon color="primary">
               mdi-file
             </v-icon>
@@ -55,7 +56,7 @@
               mdi-server
             </v-icon>
             {{ filesize(item.size) }}
-          </v-col>
+          </v-col> -->
         </v-row>
       </v-list-item>
     </v-list>
@@ -75,15 +76,18 @@ export default {
       type: Array,
       required: true,
     },
-    dandisetDetails: {
-      // nFolders and nItems
-      type: Array,
-      required: true,
-    },
+    // TODO: Uncomment this once backend detail issue is sorted
+    // dandisetDetails: {
+    //   // nFolders and nItems
+    //   type: Array,
+    //   required: true,
+    // },
   },
   computed: {
     items() {
-      return this.dandisets.map((item, i) => ({ ...item, details: this.dandisetDetails[i] }));
+      // TODO: Uncomment this once backend detail issue is sorted
+      // return this.dandisets.map((item, i) => ({ ...item, details: this.dandisetDetails[i] }));
+      return this.dandisets;
     },
   },
   methods: {


### PR DESCRIPTION
For the time being, this should be hidden, because we don't get the proper size/number of items from girder.