### PR TITLE
Add Public Dandisets View

### DIFF
--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import Vuex from 'vuex';
 
 import girder from '@/store/girder';
+import publicDandisets from '@/store/publicDandisets';
 
 Vue.use(Vuex);
 
@@ -9,5 +10,6 @@ Vue.use(Vuex);
 export default new Vuex.Store({
   modules: {
     girder,
+    publicDandisets,
   },
 });

--- a/web/src/store/publicDandisets.js
+++ b/web/src/store/publicDandisets.js
@@ -20,7 +20,6 @@ export default {
     setSearchSettings(state, { sort }) {
       state.sort = sort;
       state.page = 1;
-      this.dispatch('publicDandisets/reload');
     },
     setDandisets(state, { dandisets, total }) {
       state.dandisets = dandisets;
@@ -29,7 +28,7 @@ export default {
   },
   actions: {
     async reload({ commit, state }) {
-      const { data: dandisets, headers } = await girderRest.get('dandi/list', {
+      const { data: dandisets, headers } = await girderRest.get('dandi', {
         params: {
           limit: DANDISETS_PER_PAGE,
           offset: (state.page - 1) * DANDISETS_PER_PAGE,
@@ -39,6 +38,10 @@ export default {
       });
       const total = headers['girder-total-count'];
       commit('setDandisets', { dandisets, total });
+    },
+    async changeSearchSettings({ commit, dispatch }, { sort }) {
+      commit('setSearchSettings', { sort });
+      dispatch('reload');
     },
   },
 };

--- a/web/src/store/publicDandisets.js
+++ b/web/src/store/publicDandisets.js
@@ -1,0 +1,44 @@
+import girderRest from '@/rest';
+
+const DANDISETS_PER_PAGE = 8;
+
+export default {
+  namespaced: true,
+  state: {
+    // search settings
+    sort: {
+      field: 'created',
+      direction: 1,
+    },
+    page: 1,
+
+    // retrieved from server
+    dandisets: [],
+    pages: 0,
+  },
+  mutations: {
+    setSearchSettings(state, { sort }) {
+      state.sort = sort;
+      state.page = 1;
+      this.dispatch('publicDandisets/reload');
+    },
+    setDandisets(state, { dandisets, total }) {
+      state.dandisets = dandisets;
+      state.pages = Math.ceil(total / DANDISETS_PER_PAGE);
+    },
+  },
+  actions: {
+    async reload({ commit, state }) {
+      const { data: dandisets, headers } = await girderRest.get('dandi/list', {
+        params: {
+          limit: DANDISETS_PER_PAGE,
+          offset: (state.page - 1) * DANDISETS_PER_PAGE,
+          sort: state.sort.field,
+          sortdir: state.sort.direction,
+        },
+      });
+      const total = headers['girder-total-count'];
+      commit('setDandisets', { dandisets, total });
+    },
+  },
+};

--- a/web/src/views/PublicDandisetsView/PublicDandisetsView.vue
+++ b/web/src/views/PublicDandisetsView/PublicDandisetsView.vue
@@ -1,11 +1,96 @@
 <template>
-  <v-container>
-    TODO: PublicDandisetsView
-  </v-container>
+  <div>
+    <v-toolbar
+      color="grey darken-2 white--text"
+    >
+      <v-toolbar-title class="d-none d-md-block mx-8">
+        Public Dandisets
+      </v-toolbar-title>
+      <v-divider
+        class="d-none d-md-block"
+        vertical
+      />
+      <div class="mx-6">
+        Sort By:
+      </div>
+      <v-chip-group
+        v-model="selection"
+        active-class="white light-blue--text"
+        dark
+        mandatory
+      >
+        <v-chip
+          v-for="option in options"
+          :key="option.name"
+          @click="setSort(option.sort)"
+        >
+          {{ option.name }}
+        </v-chip>
+      </v-chip-group>
+      <SearchField />
+    </v-toolbar>
+    <DandisetList
+      class="
+        mx-12
+        my-12"
+      :dandisets="$store.state.publicDandisets.dandisets"
+    />
+    <v-pagination
+      v-model="$store.state.publicDandisets.page"
+      :length="$store.state.publicDandisets.pages"
+      :value="$store.state.publicDandisets.page"
+      @input="reload"
+    />
+  </div>
 </template>
 
 <script>
+import DandisetList from '@/components/DandisetList.vue';
+import SearchField from '@/views/PublicDandisetsView/SearchField.vue';
+
+const OPTIONS = [
+  {
+    name: 'Oldest',
+    sort: {
+      field: 'created',
+      direction: 1,
+    },
+  },
+  {
+    name: 'Newest',
+    sort: {
+      field: 'created',
+      direction: -1,
+    },
+  },
+  {
+    name: 'Name',
+    sort: {
+      field: 'meta.dandiset.name',
+      direction: 1,
+    },
+  },
+];
+
 export default {
   name: 'PublicDandisetsView',
+  components: { DandisetList, SearchField },
+  data() {
+    return {
+      selection: 'newest',
+      options: OPTIONS,
+    };
+  },
+  created() {
+    this.$store.dispatch('publicDandisets/reload');
+  },
+  methods: {
+    setSort(sort) {
+      this.$store.commit('publicDandisets/setSearchSettings', { sort });
+    },
+    reload() {
+      this.$store.dispatch('publicDandisets/reload');
+    },
+  },
 };
 </script>

--- a/web/src/views/PublicDandisetsView/PublicDandisetsView.vue
+++ b/web/src/views/PublicDandisetsView/PublicDandisetsView.vue
@@ -33,18 +33,19 @@
       class="
         mx-12
         my-12"
-      :dandisets="$store.state.publicDandisets.dandisets"
+      :dandisets="dandisets"
     />
     <v-pagination
-      v-model="$store.state.publicDandisets.page"
-      :length="$store.state.publicDandisets.pages"
-      :value="$store.state.publicDandisets.page"
+      v-model="page"
+      :value="page"
+      :length="pages"
       @input="reload"
     />
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex';
 import DandisetList from '@/components/DandisetList.vue';
 import SearchField from '@/views/PublicDandisetsView/SearchField.vue';
 
@@ -81,12 +82,23 @@ export default {
       options: OPTIONS,
     };
   },
+  computed: {
+    page: {
+      get() {
+        return this.$store.state.publicDandisets.page;
+      },
+      set(page) {
+        this.$store.state.publicDandisets.page = page;
+      },
+    },
+    ...mapState('publicDandisets', ['dandisets', 'pages']),
+  },
   created() {
-    this.$store.dispatch('publicDandisets/reload');
+    this.reload();
   },
   methods: {
     setSort(sort) {
-      this.$store.commit('publicDandisets/setSearchSettings', { sort });
+      this.$store.dispatch('publicDandisets/changeSearchSettings', { sort });
     },
     reload() {
       this.$store.dispatch('publicDandisets/reload');

--- a/web/src/views/PublicDandisetsView/SearchField.vue
+++ b/web/src/views/PublicDandisetsView/SearchField.vue
@@ -1,4 +1,4 @@
-<!-- Placeholder until comprehensive search solution is done -->
+<!-- TODO Placeholder until comprehensive search solution is done -->
 
 <template>
   <v-text-field

--- a/web/src/views/PublicDandisetsView/SearchField.vue
+++ b/web/src/views/PublicDandisetsView/SearchField.vue
@@ -1,0 +1,19 @@
+<!-- Placeholder until comprehensive search solution is done -->
+
+<template>
+  <v-text-field
+    label="Search Dandisets"
+    outlined
+    solo
+    dense
+    hide-details
+    append-icon="mdi-magnify"
+    background-color="white"
+    color="black"
+    data-id="search"
+  />
+</template>
+
+<script>
+export default { name: 'SearchField' };
+</script>


### PR DESCRIPTION
Add the first draft of the public dandisets view. I anticipate the
following changes at some point:

* UX styling for the list dandisets component. It is currently not
filling the page and still needs some more work done to get all the
stats it needs.
* Comprehensive search solution. I included a placeholder `SearchField`
that looks ok, but does nothing. When search is implemented properly it
should be replaced with a general component.
* Better search option chips. We don't have the information available to
do all of Jared's recommended chips, and the UX of what I did is
probably unsatisfactory in some way. It is fully functional and
easily fixable though, so I think it's OK for an MVP.

Some screenshots:
![Screenshot from 2020-04-06 09-12-20](https://user-images.githubusercontent.com/577946/78562145-e8caa700-77e6-11ea-9f03-a079a8ff3fe5.png)
![Screenshot from 2020-04-06 09-12-36](https://user-images.githubusercontent.com/577946/78562151-ec5e2e00-77e6-11ea-951d-9d81018eb3c7.png)
![Screenshot from 2020-04-06 09-12-55](https://user-images.githubusercontent.com/577946/78562157-eec08800-77e6-11ea-9567-752a1dedf455.png)


Fixes #181 