### PR TITLE
Fix DLP back arrow to point to listing page

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -57,7 +57,7 @@
               >
                 <v-btn
                   icon
-                  :to="`/collection/${selected.parentId}`"
+                  :to="{ name: 'publicDandisets' }"
                 >
                   <v-icon>mdi-arrow-left</v-icon>
                 </v-btn>


### PR DESCRIPTION
No associated issue but something I noticed. Current the back arrow in the DLP still points to `/collection/${selected.parentId}`, which isn't a valid route anymore. This points it back to the Public Dandisets page instead.