### PR TITLE
Redirect to home page after successful login

### DIFF
--- a/web/src/views/UserLoginView/UserLoginView.vue
+++ b/web/src/views/UserLoginView/UserLoginView.vue
@@ -1,6 +1,5 @@
 <template>
   <v-container>
-    TODO: UserLoginView
     <GirderAuth
       :force-otp="false"
       :show-forgot-password="false"
@@ -11,11 +10,22 @@
 
 <script>
 import { Authentication as GirderAuth } from '@girder/components/src/components';
+import { loggedIn } from '@/rest';
 
 export default {
   name: 'UserLoginView',
   components: {
     GirderAuth,
   },
+  computed: {
+    loggedIn,
+  },
+  watch: {
+    loggedIn(val) {
+      if (val) {
+        this.$router.push({ name: 'home' });
+      }
+    }
+  }
 };
 </script>


### PR DESCRIPTION
Before this change, logging in would leave you on the login page, causing some confusion.