### PR TITLE
Remove unnecessary source map config

### DIFF
--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -2,9 +2,6 @@ process.env.VUE_APP_VERSION = process.env.COMMIT_REF;
 
 module.exports = {
   lintOnSave: false,
-  configureWebpack: {
-    devtool: 'source-map',
-  },
   transpileDependencies: [
     'vuetify',
   ],


### PR DESCRIPTION
Vue CLI already builds production sourcemaps by default:
https://cli.vuejs.org/config/#productionsourcemap