### PR TITLE
Remove deploy-specific configuration from repo

### DIFF
--- a/web/.env.production
+++ b/web/.env.production
@@ -1,2 +1,0 @@
-VUE_APP_API_ROOT=https://girder.dandiarchive.org/api/v1
-VUE_APP_SENTRY_DSN=https://24675005ee044d2e9a8245833f1f8821@sentry.io/4282414


### PR DESCRIPTION
The settings in `.env.production` are specific to a particular deploy of the app. All production builds should not necessarily use these same settings.