### PR TITLE
RF: nwb.json => dandiset_metanwb.json

### DIFF
--- a/web/src/assets/schema/dandiset_metanwb.json
+++ b/web/src/assets/schema/dandiset_metanwb.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
   "type": "object",
-  "title": "NWB",
+  "title": "Dandiset data about metadata from NWB files schema",
   "required": [
     "sex",
     "organism",

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -165,7 +165,7 @@ import girderRest, { loggedIn } from '@/rest';
 
 import SCHEMA from '@/assets/schema/dandiset.json';
 import NEW_SCHEMA from '@/assets/schema/dandiset_new.json';
-import NWB_SCHEMA from '@/assets/schema/nwb.json';
+import NWB_SCHEMA from '@/assets/schema/dandiset_metanwb.json';
 
 export default {
   name: 'DandisetLandingView',


### PR DESCRIPTION
Initially I had missed the fact that it is not the schema we impose on top
of nwb, but rather a schema for dandiset.yaml fields which are derived from
metadata we find in nwb files.  As it is not directly the information from
nwb, I decided to call it metanwb.

I left variable `NWB_SCHEMA` as is since it seems that UI is anyways dandiset specific, but can change that one to `METANWB_SCHEMA` for clearer correspondence. Let me know

This is a follow up to previous renamings in bdf09cfed3d76a7dc73de7bcf82bdd28f984c9f2