### PR TITLE
Replace indexes in keys with values

### DIFF
--- a/web/src/components/MetaEditor.vue
+++ b/web/src/components/MetaEditor.vue
@@ -15,8 +15,8 @@
             </template>
             <template v-else>
               <v-alert
-                v-for="(error, i) in errors"
-                :key="i"
+                v-for="error in errors"
+                :key="error.schemaPath"
                 dense
                 type="error"
                 text-color="white"

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -117,8 +117,8 @@
                 <template v-if="meta.contributors">
                   <v-subheader>Contributors</v-subheader>
                   <v-list-item
-                    v-for="(item, i) in meta.contributors"
-                    :key="i"
+                    v-for="item in meta.contributors"
+                    :key="item.orcid || `${item.name}-${item.roles}`"
                     selectable
                   >
                     <v-list-item-content>{{ item }}</v-list-item-content>
@@ -129,7 +129,7 @@
                     {{ k }}
                   </v-subheader>
                   <v-list-item
-                    :key="k"
+                    :key="`${k}-item`"
                     selectable
                   >
                     <v-list-item-content>


### PR DESCRIPTION
Closes #240.

There's also a lingering use of this in `MetaNode.vue`:

https://github.com/dandi/dandiarchive/blob/c7e5237fef6d0bd65726b4db39ebe46b14b7d128/web/src/components/MetaNode.vue#L95

However, perhaps when making the change to linting, or just at some point during the refactor, the template for this component has been tangled, so additional work will need to be done to fix this, along with that change.