### PR TITLE
309 search usability

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -41,7 +41,7 @@
               ·
               Created on <b>{{ formatDate(item.created) }}</b>
               ·
-              DANDI:<b>{{item.meta.dandiset.identifier}}</b>  
+              DANDI:<b>{{ item.meta.dandiset.identifier }}</b>
             </v-list-item-subtitle>
           </v-list-item-content>
         </v-col>

--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -11,7 +11,7 @@
       color="black"
       @input="updateSearch"
     >
-      <template v-slot:append>
+      <template v-slot:prepend-inner>
         <v-icon @click="performSearch">
           mdi-magnify
         </v-icon>

--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -2,7 +2,7 @@
   <v-form @submit="performSearch">
     <v-text-field
       :value="$route.query.search"
-      label="Search Dandisets"
+      label="Search Dandisets by name, description, or identifier"
       outlined
       solo
       hide-details

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -48,8 +48,8 @@
       >
         <v-col>
           <v-progress-circular
-            indeterminate
             v-if="!dandisets"
+            indeterminate
           />
           <slot
             v-else

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -33,12 +33,31 @@
           </v-icon>
         </v-chip>
       </v-chip-group>
-      <DandisetSearchField />
+      <DandisetSearchField class="flex-grow-1" />
     </v-toolbar>
     <DandisetList
+      v-if="dandisets && dandisets.length"
       class="mx-12 my-12"
       :dandisets="dandisets"
     />
+    <v-container v-else>
+      <v-row
+        class="text-center ma-12 grey--text"
+        align="center"
+        justify="center"
+      >
+        <v-col>
+          <v-progress-circular
+            indeterminate
+            v-if="!dandisets"
+          />
+          <slot
+            v-else
+            name="no-content"
+          />
+        </v-col>
+      </v-row>
+    </v-container>
     <v-pagination
       v-model="page"
       :length="pages"
@@ -117,7 +136,7 @@ export default {
       return { page, sortOption, sortDir };
     },
     dandisets() {
-      return this.dandisetRequest ? this.dandisetRequest.data : [];
+      return this.dandisetRequest ? this.dandisetRequest.data : undefined;
     },
     totalDandisets() {
       return this.dandisetRequest ? this.dandisetRequest.headers['girder-total-count'] : 0;

--- a/web/src/views/MyDandisetsView/MyDandisetsView.vue
+++ b/web/src/views/MyDandisetsView/MyDandisetsView.vue
@@ -2,7 +2,13 @@
   <DandisetsPage
     title="My Dandisets"
     user
-  />
+  >
+    <template #no-content>
+      <div>
+        You haven't created any dandisets yet
+      </div>
+    </template>
+  </DandisetsPage>
 </template>
 
 <script>

--- a/web/src/views/SearchDandisetsView/SearchDandisetsView.vue
+++ b/web/src/views/SearchDandisetsView/SearchDandisetsView.vue
@@ -2,7 +2,16 @@
   <DandisetsPage
     title="Search Dandisets"
     search
-  />
+  >
+    <template #no-content>
+      <div>
+        No results!
+      </div>
+      <div>
+        You can search by dandiset name, description, or identifier.
+      </div>
+    </template>
+  </DandisetsPage>
 </template>
 
 <script>

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -8,5 +8,5 @@ module.exports = {
   devServer: {
     // The default port 8080 conflicts with Girder
     port: 8085,
-  }
+  },
 };


### PR DESCRIPTION
* Search fields now contain the placeholder `Search Dandisets by name,
description, or identifier` to document intended usage
* Dandisets pages will now expand the search bar to fill remaining space
in the toolbar (so that the full placeholder text can be seen)
* Dandisets pages will now show a spinner while waiting for content to
load
* Dandisets pages now provide a slot for the text to display when there
are no dandisets to list
* My Dandisets will now say `You haven't created any dandisets yet`
* Search Dandisets will now provide some concise assistance if you have
no search results
* Some unrelated files were linted

fixes #309 