### PR TITLE
Refactor file browser

### DIFF
--- a/web/src/components/MetaEditor.vue
+++ b/web/src/components/MetaEditor.vue
@@ -175,7 +175,7 @@ export default {
       return this.yamlOutput ? jsYaml.dump(this.meta) : JSON.stringify(this.meta, null, 2);
     },
     ...mapState('girder', {
-      id: (state) => state.selected[0]._id,
+      id: (state) => (state.currentDandiset ? state.currentDandiset._id : null),
     }),
   },
   watch: {
@@ -199,7 +199,7 @@ export default {
       const { status, data } = await girderRest.put(`folder/${this.id}/metadata`, { dandiset: this.meta });
 
       if (status === 200) {
-        this.setSelected([data]);
+        this.setCurrentDandiset(data);
       }
 
       this.closeEditor();
@@ -236,7 +236,7 @@ export default {
       link.click();
       URL.revokeObjectURL(link.href);
     },
-    ...mapMutations('girder', ['setSelected']),
+    ...mapMutations('girder', ['setCurrentDandiset']),
   },
 };
 </script>

--- a/web/src/components/MetaNode.vue
+++ b/web/src/components/MetaNode.vue
@@ -167,7 +167,7 @@ export default {
       required: true,
     },
     initial: {
-      type: Object,
+      type: [Object, Array, String, Number],
       default: null,
       required: false,
     },

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Router from 'vue-router';
+import FileBrowser from '@/views/FileBrowserView/FileBrowser.vue';
 
 import HomeView from '@/views/HomeView/HomeView.vue';
 import UserLoginView from '@/views/UserLoginView/UserLoginView.vue';
@@ -18,6 +19,11 @@ export default new Router({
       path: '/',
       name: 'home',
       component: HomeView,
+    },
+    {
+      path: '/file-browser/:_modelType?/:_id?',
+      name: 'file-browser',
+      component: FileBrowser,
     },
     {
       path: '/user/login',

--- a/web/src/store/girder.js
+++ b/web/src/store/girder.js
@@ -7,6 +7,7 @@ export default {
   state: {
     browseLocation: null,
     selected: [],
+    currentDandiset: null,
   },
   getters: {
     loggedIn,
@@ -15,27 +16,14 @@ export default {
     setSelected(state, selected) {
       state.selected = selected;
     },
+    setCurrentDandiset(state, dandiset) {
+      state.currentDandiset = dandiset;
+    },
     setBrowseLocation(state, location) {
       state.browseLocation = location;
     },
   },
   actions: {
-    async selectSearchResult({ commit }, result) {
-      commit('setSelected', []);
-
-      if (result._modelType === 'item') {
-        const resp = await girderRest.get(`folder/${result.folderId}`);
-        commit('setBrowseLocation', resp.data);
-        // Because setting the location is going to trigger the DataBrowser to
-        // set its selected value to [], which due to two-way binding also propagates back
-        // up to this component, we must defer this to the next tick so that this runs after that,
-        // as we have no way to update the DataBrowser location without having it also reset the
-        // selection internally.
-        Vue.nextTick(() => { commit('setSelected', [result]); });
-      } else {
-        commit('setBrowseLocation', result);
-      }
-    },
     async fetchFullLocation({ commit }, location) {
       if (location && location._id && location._modelType) {
         const { _id: id, _modelType: modelType } = location;

--- a/web/src/store/girder.js
+++ b/web/src/store/girder.js
@@ -1,5 +1,3 @@
-import Vue from 'vue';
-
 import girderRest, { loggedIn } from '@/rest';
 
 export default {

--- a/web/src/store/girder.js
+++ b/web/src/store/girder.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 
-import girderRest from '@/rest';
+import girderRest, { loggedIn } from '@/rest';
 
 export default {
   namespaced: true,
@@ -8,9 +8,15 @@ export default {
     browseLocation: null,
     selected: [],
   },
+  getters: {
+    loggedIn,
+  },
   mutations: {
     setSelected(state, selected) {
       state.selected = selected;
+    },
+    setBrowseLocation(state, location) {
+      state.browseLocation = location;
     },
   },
   actions: {
@@ -28,6 +34,16 @@ export default {
         Vue.nextTick(() => { commit('setSelected', [result]); });
       } else {
         commit('setBrowseLocation', result);
+      }
+    },
+    async fetchFullLocation({ commit }, location) {
+      if (location && location._id && location._modelType) {
+        const { _id: id, _modelType: modelType } = location;
+
+        const { status, data } = await girderRest.get(`${modelType}/${id}`);
+        if (status === 200) {
+          commit('setBrowseLocation', data);
+        }
       }
     },
     async logout() {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -233,7 +233,7 @@ export default {
       return filesize(this.selected.size);
     },
     ...mapState('girder', {
-      selected: (state) => (state.selected.length === 1 ? state.selected[0] : undefined),
+      selected: (state) => state.currentDandiset,
     }),
   },
   watch: {
@@ -261,8 +261,8 @@ export default {
       immediate: true,
       async handler(value) {
         if (!this.selected || !this.meta.length) {
-          const resp = await girderRest.get(`folder/${value}`);
-          this.$store.commit('girder/setSelected', [resp.data]);
+          const { data } = await girderRest.get(`folder/${value}`);
+          this.$store.commit('girder/setCurrentDandiset', data);
         }
       },
     },

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -79,7 +79,7 @@
                   You must be logged in to edit.
                 </v-tooltip>
                 <v-btn
-                  :to="`/folder/${id}`"
+                  :to="{ name: 'file-browser', params: { _id: id, _modelType: 'folder' }}"
                   icon
                 >
                   <v-icon>mdi-file-tree</v-icon>

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -107,14 +107,25 @@ export default {
     },
     location: {
       get() {
-        return this.browseLocation;
+        return this.$store.state.girder.browseLocation;
       },
       set(value) {
         this.setBrowseLocation(value);
       },
     },
-    ...mapState('girder', ['browseLocation', 'selected']),
+    ...mapState('girder', ['selected']),
     ...mapGetters('girder', ['loggedIn']),
+  },
+  watch: {
+    location(newValue, oldValue) {
+      if (
+        !oldValue === null
+        || newValue._modelType !== oldValue._modelType
+        || newValue._id !== oldValue._id
+      ) {
+        this.$router.push({ name: 'file-browser', params: { _modelType: newValue._modelType, _id: newValue._id } });
+      }
+    },
   },
   created() {
     const location = getLocationFromRoute(this.$route);

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -117,12 +117,10 @@ export default {
     ...mapGetters('girder', ['loggedIn']),
   },
   watch: {
-    location(newValue, oldValue) {
-      if (
-        !oldValue === null
-        || newValue._modelType !== oldValue._modelType
-        || newValue._id !== oldValue._id
-      ) {
+    location(newValue) {
+      const { _modelType, _id } = this.$route.params;
+
+      if (newValue._modelType !== _modelType || newValue._id !== _id) {
         this.$router.push({ name: 'file-browser', params: { _modelType: newValue._modelType, _id: newValue._id } });
       }
     },

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -1,0 +1,134 @@
+<template>
+  <v-container style="height: 100%;">
+    <v-row v-if="selected">
+      <v-col :cols="selected.length ? 8 : 12">
+        <girder-file-manager
+          :selectable="true"
+          :location.sync="location"
+          :upload-enabled="false"
+          :value="selected"
+          :initial-items-per-page="25"
+          :items-per-page-options="[10,25,50,100,-1]"
+          @input="setSelected"
+        >
+          <template
+            v-if="isDandiset"
+            v-slot:headerwidget
+          >
+            <v-btn
+              icon
+              color="primary"
+              :to="{ name: 'dandisetLanding', params: { id: location._id }}"
+            >
+              <v-icon>mdi-eye</v-icon>
+            </v-btn>
+          </template>
+        </girder-file-manager>
+      </v-col>
+      <v-col
+        v-if="selected.length"
+        cols="4"
+      >
+        <girder-data-details
+          :value="selected"
+          :action-keys="actions"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import {
+  mapGetters,
+  mapMutations,
+  mapState,
+  mapActions,
+} from 'vuex';
+import { DataDetails as GirderDataDetails } from '@girder/components/src/components';
+import { DefaultActionKeys } from '@girder/components/src/components/DataDetails.vue';
+import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+
+import {
+  getLocationFromRoute,
+} from '@/utils';
+
+// redirect to "Open JupyterLab"
+const JUPYTER_ROOT = 'https://hub.dandiarchive.org';
+
+const actionKeys = [
+  {
+    for: ['item'],
+    name: 'Open JupyterLab',
+    icon: 'mdi-language-python',
+    color: 'primary',
+    handler() {
+      window.open(`${JUPYTER_ROOT}`, '_blank');
+    },
+  },
+  // Download for items only
+  DefaultActionKeys[1],
+];
+
+export default {
+  components: { GirderDataDetails, GirderFileManager },
+  computed: {
+    isDandiset() {
+      return !!(this.location && this.location.meta && this.location.meta.dandiset);
+    },
+    actions() {
+      let actions = actionKeys;
+      if (
+        this.selected.length === 1
+        && this.selected[0].meta
+        && this.selected[0].meta.dandiset
+      ) {
+        const id = this.selected[0]._id;
+
+        actions = [
+          {
+            for: ['folder'],
+            name: 'View DANDI Metadata',
+            icon: 'mdi-pencil',
+            color: 'primary',
+            handler() {
+              // eslint-disable-next-line
+              this.$router.push({
+                name: 'dandiset-metadata-viewer',
+                params: { id },
+              });
+            },
+          },
+          ...actionKeys,
+        ];
+      }
+
+      return actions;
+    },
+    location: {
+      get() {
+        return this.browseLocation;
+      },
+      set(value) {
+        this.setBrowseLocation(value);
+      },
+    },
+    ...mapState('girder', ['browseLocation', 'selected']),
+    ...mapGetters('girder', ['loggedIn']),
+  },
+  created() {
+    const location = getLocationFromRoute(this.$route);
+    this.setBrowseLocation(location);
+    this.fetchFullLocation(location);
+  },
+  methods: {
+    ...mapMutations('girder', ['setBrowseLocation', 'setSelected']),
+    ...mapActions('girder', ['fetchFullLocation']),
+  },
+};
+</script>
+<style>
+.girder-file-browser .secondary .row .spacer {
+  display: none;
+}
+</style>

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -3,9 +3,9 @@
     <v-row v-if="selected">
       <v-col :cols="selected.length ? 8 : 12">
         <girder-file-manager
-          :selectable="true"
+          selectable
+          root-location-disabled
           :location.sync="location"
-          :upload-enabled="false"
           :value="selected"
           :initial-items-per-page="25"
           :items-per-page-options="[10,25,50,100,-1]"
@@ -62,9 +62,10 @@ const actionKeys = [
     name: 'Open JupyterLab',
     icon: 'mdi-language-python',
     color: 'primary',
-    handler() {
-      window.open(`${JUPYTER_ROOT}`, '_blank');
+    generateHref() {
+      return JUPYTER_ROOT;
     },
+    target: '_blank',
   },
   // Download for items only
   DefaultActionKeys[1],


### PR DESCRIPTION
Fixes #303.

This adds back in `FileBrowser.vue`, and adds a new girder state property `currentDandiset`, instead of hackily using `selected`, which is meant to be used by the hierarchy widget.