### PR TITLE
Add compound indexes for dandiset name and description

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -21,7 +21,9 @@ class DandiArchivePlugin(GirderPlugin):
         # Mongo is not guaranteed to use a singular index when executing the query.
         # meta.dandiset.identifier is specified first so that it is available as an
         # index for other queries that might need it.
+        Folder().ensureIndex(([("meta.dandiset.name", 1), ("parentId", 1)], {}))
         Folder().ensureIndex(([("meta.dandiset.identifier", 1), ("parentId", 1)], {}))
+        Folder().ensureIndex(([("meta.dandiset.description", 1), ("parentId", 1)], {}))
 
         Setting().collection.update(
             {"key": DANDISET_IDENTIFIER_COUNTER}, {"$setOnInsert": {"value": 1}}, upsert=True,


### PR DESCRIPTION
Fixes #314.

I'm not sure if this actually improves the search time, testing locally didn't seem to have much of a difference, but it's probably still good to have these extra indexes anyway. I'm not sure if there's any downsides to this.