### PR TITLE
Replace JSON rendering with better looking component

### DIFF
--- a/web/src/assets/schema/dandiset.json
+++ b/web/src/assets/schema/dandiset.json
@@ -296,7 +296,7 @@
       "title": "Ethics Approvals",
       "items": {
         "$id": "#/properties/ethicsApprovals/items",
-        "type": "array",
+        "type": "object",
         "title": "Items",
         "required": [
           "name",

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -116,32 +116,29 @@
                 </template>
                 <template v-if="meta.contributors">
                   <v-subheader>Contributors</v-subheader>
-                  <v-list-item
-                    v-for="item in meta.contributors"
-                    :key="item.orcid || `${item.name}-${item.roles}`"
-                    selectable
-                  >
-                    <v-list-item-content>{{ item }}</v-list-item-content>
+                  <v-list-item>
+                    <ListingComponent
+                      :data="meta.contributors"
+                      :schema="schema.properties.contributors"
+                    />
                   </v-list-item>
                 </template>
+
+                <!-- END OF HARD CODED FIELDS -->
+
                 <template v-for="(item, k) in extraFields">
                   <v-subheader :key="k">
-                    {{ k }}
+                    {{ schema.properties[k].title }}
                   </v-subheader>
                   <v-list-item
                     :key="`${k}-item`"
                     selectable
                   >
                     <v-list-item-content>
-                      <template v-if="['object', 'array'].includes(schema.properties[k].type)">
-                        <vue-json-pretty
-                          :data="item"
-                          highlight-mouseover-node
-                        />
-                      </template>
-                      <template v-else>
-                        {{ item }}
-                      </template>
+                      <ListingComponent
+                        :schema="schema.properties[k]"
+                        :data="item"
+                      />
                     </v-list-item-content>
                   </v-list-item>
                 </template>
@@ -157,9 +154,9 @@
 <script>
 import filesize from 'filesize';
 import { mapState } from 'vuex';
-import VueJsonPretty from 'vue-json-pretty';
 
 import MetaEditor from '@/components/MetaEditor.vue';
+import ListingComponent from '@/views/DandisetLandingView/ListingComponent.vue';
 import { dandiUrl } from '@/utils';
 import girderRest, { loggedIn } from '@/rest';
 
@@ -171,7 +168,7 @@ export default {
   name: 'DandisetLandingView',
   components: {
     MetaEditor,
-    VueJsonPretty,
+    ListingComponent,
   },
   props: {
     id: {

--- a/web/src/views/DandisetLandingView/ListingComponent.vue
+++ b/web/src/views/DandisetLandingView/ListingComponent.vue
@@ -26,6 +26,15 @@
           </v-expansion-panel>
         </v-expansion-panels>
       </template>
+      <template v-else-if="schema.items.type === 'array'">
+        <!-- May not work. Not tested in a real scenario. -->
+        <ListingComponent
+          v-for="item in data"
+          :key="item"
+          :schema="schema.items"
+          :data="item"
+        />
+      </template>
       <template v-else>
         <b>{{ schema.title }}</b>: {{ data.join(', ') }}
       </template>

--- a/web/src/views/DandisetLandingView/ListingComponent.vue
+++ b/web/src/views/DandisetLandingView/ListingComponent.vue
@@ -5,10 +5,10 @@
         <v-expansion-panels>
           <v-expansion-panel
             v-for="item in data"
-            :key="item[schema.items.listingKey]"
+            :key="item[primaryKey]"
           >
             <!-- item is an object -->
-            <v-expansion-panel-header>{{ item[schema.items.listingKey] }}</v-expansion-panel-header>
+            <v-expansion-panel-header>{{ item[primaryKey] }}</v-expansion-panel-header>
             <v-expansion-panel-content>
               <v-list>
                 <v-list-item
@@ -63,6 +63,20 @@ export default {
       // The data at the matching level of schema
       type: [Object, Number, String, Array],
       required: true,
+    },
+  },
+  computed: {
+    primaryKey() {
+      switch (this.schema.title) {
+        case 'Access':
+          return 'status';
+        case 'Publications':
+          return 'url';
+        case 'Organism':
+          return 'species';
+        default:
+          return 'name';
+      }
     },
   },
 };

--- a/web/src/views/DandisetLandingView/ListingComponent.vue
+++ b/web/src/views/DandisetLandingView/ListingComponent.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <template v-if="schema.type === 'array'">
+      <template v-if="schema.items.type === 'object'">
+        <v-expansion-panels>
+          <v-expansion-panel
+            v-for="item in data"
+            :key="item[schema.items.listingKey]"
+          >
+            <!-- item is an object -->
+            <v-expansion-panel-header>{{ item[schema.items.listingKey] }}</v-expansion-panel-header>
+            <v-expansion-panel-content>
+              <v-list>
+                <v-list-item
+                  v-for="(value, key) in item"
+                  :key="key"
+                >
+                  <!-- value's type matches that specified at schema.items.properties[key].type -->
+                  <ListingComponent
+                    :schema="schema.items.properties[key]"
+                    :data="value"
+                  />
+                </v-list-item>
+              </v-list>
+            </v-expansion-panel-content>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </template>
+      <template v-else>
+        <b>{{ schema.title }}</b>: {{ data.join(', ') }}
+      </template>
+    </template>
+    <template v-else-if="schema.type === 'object'">
+      <v-list>
+        <v-list-item
+          v-for="(value, key) in data"
+          :key="key"
+        >
+          <ListingComponent
+            :schema="schema.properties[key]"
+            :data="value"
+          />
+        </v-list-item>
+      </v-list>
+    </template>
+    <template v-else>
+      <!-- Base Case -->
+      <b>{{ schema.title }}</b>: {{ data }}
+    </template>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ListingComponent',
+  props: {
+    schema: {
+      // The root schema of the item to render
+      type: [Object],
+      required: true,
+    },
+    data: {
+      // The data at the matching level of schema
+      type: [Object, Number, String, Array],
+      required: true,
+    },
+  },
+};
+</script>


### PR DESCRIPTION
Fixes #206.

This involves adding a piece of metadata to the schema, `listingKey`. This is to be specified at the same level as a `required` field, and specifies which of the properties of an object should be used to represent it at a top level. I'm open to suggestions about renaming this field to whatever best suits it, but I just chose a name to get moving on it. @satra It would be good for you to confirm that the `listingKey` I specified on each property is actually what it should be. Most of the time it's `name`, but does vary.

This also adds a component, `DandisetLandingView/ListingComponent.vue`, which is recursive and is only used in the `DandisetLandingView` page.