### PR TITLE
Sync edit and delete actions with underlying permissions

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,8 @@
         {
           "allow": [
             "_id",
-            "_modelType"
+            "_modelType",
+            "_accessLevel"
           ]
         }
       ]

--- a/web/src/components/MetaEditor.vue
+++ b/web/src/components/MetaEditor.vue
@@ -220,10 +220,12 @@ export default {
           this.setCurrentDandiset(data);
           this.closeEditor();
         }
-      } catch ({ response: { status } }) {
-        if (status === 403) {
+      } catch (error) {
+        if (error.response.status === 403) {
           this.invalidPermissionSnackbar = true;
         }
+
+        throw error;
       }
     },
     publish() {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -63,20 +63,20 @@
                 </v-btn>
                 <v-tooltip
                   right
-                  :disabled="loggedIn"
+                  :disabled="editDisabledMessage === null"
                 >
                   <template v-slot:activator="{ on }">
                     <div v-on="on">
                       <v-btn
                         icon
-                        :disabled="!loggedIn"
+                        :disabled="editDisabledMessage !== null"
                         @click="edit = true"
                       >
                         <v-icon>mdi-pencil</v-icon>
                       </v-btn>
                     </div>
                   </template>
-                  You must be logged in to edit.
+                  {{ editDisabledMessage }}
                 </v-tooltip>
                 <v-btn
                   :to="{ name: 'file-browser', params: { _id: id, _modelType: 'folder' }}"
@@ -201,6 +201,17 @@ export default {
   },
   computed: {
     loggedIn,
+    editDisabledMessage() {
+      if (!this.loggedIn) {
+        return 'You must be logged in to edit.';
+      }
+
+      if (this.selected._accessLevel < 1) {
+        return 'You do not have permission to edit this dandiset.';
+      }
+
+      return null;
+    },
     schema() {
       if (this.create) {
         return NEW_SCHEMA;

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -200,9 +200,8 @@ export default {
     };
   },
   computed: {
-    loggedIn,
     editDisabledMessage() {
-      if (!this.loggedIn) {
+      if (!loggedIn) {
         return 'You must be logged in to edit.';
       }
 

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -78,7 +78,12 @@ export default {
       return !!(this.location && this.location.meta && this.location.meta.dandiset);
     },
     actions() {
-      let actions = actionKeys;
+      const actions = [...actionKeys];
+      const canDelete = (resource) => (
+        (resource._modelType === 'folder' && resource._accessLevel === 2)
+        || (resource._modelType === 'item' && this.location._accessLevel === 2)
+      );
+
       if (
         this.selected.length === 1
         && this.selected[0].meta
@@ -86,22 +91,23 @@ export default {
       ) {
         const id = this.selected[0]._id;
 
-        actions = [
-          {
-            for: ['folder'],
-            name: 'View DANDI Metadata',
-            icon: 'mdi-pencil',
-            color: 'primary',
-            handler() {
-              // eslint-disable-next-line
+        actions.push({
+          for: ['folder'],
+          name: 'View DANDI Metadata',
+          icon: 'mdi-pencil',
+          color: 'primary',
+          handler() {
+            // eslint-disable-next-line
               this.$router.push({
-                name: 'dandiset-metadata-viewer',
-                params: { id },
-              });
-            },
+              name: 'dandiset-metadata-viewer',
+              params: { id },
+            });
           },
-          ...actionKeys,
-        ];
+        });
+      }
+
+      if (this.selected.every((item) => canDelete(item))) {
+        actions.push(DefaultActionKeys[3]);
       }
 
       return actions;

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -3,6 +3,7 @@
     <v-row v-if="selected">
       <v-col :cols="selected.length ? 8 : 12">
         <girder-file-manager
+          ref="girderFileManager"
           selectable
           root-location-disabled
           :location.sync="location"
@@ -32,6 +33,7 @@
         <girder-data-details
           :value="selected"
           :action-keys="actions"
+          @action="handleAction"
         />
       </v-col>
     </v-row>
@@ -138,6 +140,12 @@ export default {
     this.fetchFullLocation(location);
   },
   methods: {
+    async handleAction(action) {
+      if (action.name === 'Delete') {
+        await this.$refs.girderFileManager.refresh();
+        this.setSelected([]);
+      }
+    },
     ...mapMutations('girder', ['setBrowseLocation', 'setSelected']),
     ...mapActions('girder', ['fetchFullLocation']),
   },


### PR DESCRIPTION
Fixes #158.
Fixes #100. 

@satra This addresses both concerns outlined in that issue. While I think I covered all of the edge cases for deleting an items/folders, it would be good for you to double check this (obviously not by actually deleting things, but just ensuring that the delete button appears when you expect it to).