### PR TITLE
Remove vuetify xpaths boilerplate

### DIFF
--- a/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
+++ b/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
@@ -13,17 +13,17 @@ function isXPath(text) {
  * If the argument is an array, the function is called recursively and multiple predicates are
  * returned in the same string.
  *
- * @param {any} contents the contents of the element to form a predicate for
+ * @param {any} content the content of the element to form a predicate for
  */
-function contentsAsPredicate(contents) {
-  if (Array.isArray(contents)) {
-    return contents.map((c) => contentsAsPredicate(c)).join('');
+function contentsAsPredicate(content) {
+  if (Array.isArray(content)) {
+    return content.map((c) => contentsAsPredicate(c)).join('');
   }
-  if (typeof contents === 'string') {
-    if (isXPath(contents)) {
-      return `[.${contents}]`;
+  if (typeof content === 'string') {
+    if (isXPath(content)) {
+      return `[.${content}]`;
     }
-    return `[contains(text(),"${contents}")]`;
+    return `[contains(text(),"${content}")]`;
   }
   return '';
 }
@@ -45,50 +45,68 @@ function classAsPredicate(...classes) {
   }).join('');
 }
 
-export function vAvatar(contents, { cssClass } = {}) {
-  return `//div${classAsPredicate('v-avatar', cssClass)}[span${contentsAsPredicate(contents)}]`;
+/**
+ * Formats an element of a component as a XPath predicate.
+ * Vuetify components will generally have this structure for sub-elements,
+ * so this helper saves a lot of boilerplate.
+ *
+ * @param {String} name the name of the Vuetify component
+ * @param {String} element the name of the element
+ * @param {String} value the contents of the element
+ */
+function elementAsPredicate(name, element, value) {
+  return (value) ? `[.//*[@class='${name}__${element}']${contentsAsPredicate(value)}]` : '';
 }
 
-export function vBtn(contents, { cssClass } = {}) {
-  return `//*${classAsPredicate('v-btn', cssClass)}[span${contentsAsPredicate(contents)}]`;
+/**
+ * Formats a list of elements of a component as a XPath predicate.
+ * This is a wrapper for elementAsPredicate that handles multiple elements.
+ *
+ * @param {*} name the name of the Vuetify component
+ * @param {*} values the contents of each element
+ */
+function elementsAsPredicate(name, values) {
+  return Object.keys(values).map((key) => elementAsPredicate(name, key, values[key])).join('');
 }
 
-export function vCard(contents, { cssClass, title, actions } = {}) {
-  const titlePredicate = (title) ? `[div[@class='v-card__title']${contentsAsPredicate(title)}]` : '';
-  const actionsPredicate = (actions) ? `[div[@class='v-card__actions']${contentsAsPredicate(actions)}]` : '';
-  return `//div${classAsPredicate('v-card', cssClass)}${titlePredicate}${actionsPredicate}${contentsAsPredicate(contents)}`;
+
+export function vAvatar(content, { cssClass } = {}) {
+  return `//div${classAsPredicate('v-avatar', cssClass)}[span${contentsAsPredicate(content)}]`;
 }
 
-export function vChip(contents, { cssClass } = {}) {
-  return `//*${classAsPredicate('v-chip', cssClass)}[*[@class='v-chip__content']${contentsAsPredicate(contents)}]`;
+export function vBtn(content, { cssClass } = {}) {
+  return `//*${classAsPredicate('v-btn', cssClass)}[span${contentsAsPredicate(content)}]`;
+}
+
+export function vCard(content, { cssClass, title, actions } = {}) {
+  return `//div${classAsPredicate('v-card', cssClass)}${elementsAsPredicate('v-card', { title, actions })}${contentsAsPredicate(content)}`;
+}
+
+export function vChip(content, { cssClass } = {}) {
+  return `//*${classAsPredicate('v-chip', cssClass)}[*[@class='v-chip__content']${contentsAsPredicate(content)}]`;
 }
 
 export function vIcon(icon, { cssClass } = {}) {
   return `//*${classAsPredicate('v-icon', icon, cssClass)}`;
 }
 
-export function vListItem(contents, { action, title, subtitle } = {}) {
-  const contentsPredicate = (contents) ? `[.//div[@class='v-list-item__content']${contentsAsPredicate(contents)}]` : '';
-  const actionPredicate = (action) ? `[.//div[@class='v-list-item__action']${contentsAsPredicate(action)}]` : '';
-  const titlePredicate = (title) ? `[.//div[@class='v-list-item__title']${contentsAsPredicate(title)}]` : '';
-  const subtitlePredicate = (subtitle) ? `[//div[@class='v-list-item__subtitle']${contentsAsPredicate(subtitle)}]` : '';
-  return `//*${classAsPredicate('v-list-item')}${contentsPredicate}${actionPredicate}${titlePredicate}${subtitlePredicate}`;
+export function vListItem(content, { action, title, subtitle } = {}) {
+  return `//*${classAsPredicate('v-list-item')}${elementsAsPredicate('v-list-item', { content, action, title, subtitle })}`;
 }
 
-export function vListItemTitle(contents, { cssClass } = {}) {
-  return `//div${classAsPredicate('v-list-item__title', cssClass)}${contentsAsPredicate(contents)}`;
+export function vListItemTitle(content, { cssClass } = {}) {
+  return `//div${classAsPredicate('v-list-item__title', cssClass)}${contentsAsPredicate(content)}`;
 }
 
 export function vTextarea(label, { cssClass } = {}) {
   return `//div${classAsPredicate('v-textarea', cssClass)}//div[label[contains(text(),"${label}")]]//textarea`;
 }
 
-
 export function vTextField(label, { cssClass } = {}) {
   const labelPredicate = (label) ? `[.//div[label[contains(text(),"${label}")]]]` : '';
   return `//div${classAsPredicate('v-text-field', cssClass)}${labelPredicate}//input`;
 }
 
-export function vToolbar(contents, { cssClass } = {}) {
-  return `//*${classAsPredicate('v-toolbar', cssClass)}[*[@class='v-toolbar__content']${contentsAsPredicate(contents)}]`;
+export function vToolbar(content, { cssClass } = {}) {
+  return `//*${classAsPredicate('v-toolbar', cssClass)}[*[@class='v-toolbar__content']${contentsAsPredicate(content)}]`;
 }

--- a/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
+++ b/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
@@ -91,7 +91,9 @@ export function vIcon(icon, { cssClass } = {}) {
 }
 
 export function vListItem(content, { action, title, subtitle } = {}) {
-  return `//*${classAsPredicate('v-list-item')}${elementsAsPredicate('v-list-item', { content, action, title, subtitle })}`;
+  return `//*${classAsPredicate('v-list-item')}${elementsAsPredicate('v-list-item', {
+    content, action, title, subtitle,
+  })}`;
 }
 
 export function vListItemTitle(content, { cssClass } = {}) {


### PR DESCRIPTION
Cleaning up some boilerplate in the vuetify-xpaths library. Currently there isn't too much, but as more options are added for fields these helpers will grow more and more useful.