### PR TITLE
Add use of util functions

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -78,7 +78,6 @@ class DandiResource(Resource):
     )
     @dandiset_identifier
     def get_dandiset(self, identifier, params):
-        # Ensure we are only looking for drafts collection child folders.
         doc = find_dandiset_by_identifier(identifier)
         if not doc:
             raise RestException("No such dandiset found.")
@@ -187,7 +186,6 @@ class DandiResource(Resource):
         Description("List Dandisets").pagingParams(defaultSort="meta.dandiset.identifier")
     )
     def list_dandisets(self, limit, offset, sort):
-        # Ensure we are only looking for drafts collection child folders.
         return dandiset_find({}, limit=limit, offset=offset, sort=sort)
 
     @access.public
@@ -197,9 +195,6 @@ class DandiResource(Resource):
         .pagingParams(defaultSort="meta.dandiset.identifier")
     )
     def search_dandisets(self, search, limit, offset, sort):
-        # Ensure we are only looking for drafts collection child folders.
-        # TODO Currently only searching identifier, name, description, and contributor name
-        # of public dandisets
         if not search:
             # Empty search string should return all possible results
             return dandiset_find({}, limit=limit, offset=offset, sort=sort)

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -38,6 +38,7 @@ def find_dandiset_by_identifier(identifier):
 
 def dandiset_find(query, **kwargs):
     """Search for dandisets within the dandiset drafts collection."""
+    # Ensure we are only looking for drafts collection child folders.
     drafts = get_or_create_drafts_collection()
     return Folder().find({"parentId": drafts["_id"], **query}, **kwargs)
 

--- a/girder-dandi-archive/girder_dandi_archive/util.py
+++ b/girder-dandi-archive/girder_dandi_archive/util.py
@@ -36,6 +36,12 @@ def find_dandiset_by_identifier(identifier):
     return Folder().findOne({"parentId": drafts["_id"], "meta.dandiset.identifier": identifier})
 
 
+def dandiset_find(query, **kwargs):
+    """Search for dandisets within the dandiset drafts collection."""
+    drafts = get_or_create_drafts_collection()
+    return Folder().find({"parentId": drafts["_id"], **query}, **kwargs)
+
+
 def dandiset_identifier(func):
     """Raise a ValidationException if the passed dandi identifier is invalid."""
 


### PR DESCRIPTION
The main benefit of this is removing the need to specify `{"parentId": drafts["_id"]}` everywhere, which cleans up the code as well as offering an abstracted way of finding dandisets by their identifier (via `find_dandiset_by_identifier`).