### PR TITLE
Add most recent published version to lists pages

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -16,24 +16,22 @@
         <v-col cols="12">
           <v-list-item-content>
             <v-list-item-title>
-              <template v-if="item.meta.dandiset.version">
-                <v-chip
-                  v-if="item.meta.dandiset.version === 'draft'"
-                  small
-                  color="amber lighten-3"
-                  text-color="amber darken-4"
-                >
-                  <b>DRAFT</b>
-                </v-chip>
-                <v-chip
-                  v-else
-                  small
-                  color="light-blue lighten-4"
-                  text-color="light-blue darken-3"
-                >
-                  <b>{{ item.meta.dandiset.version }}</b>
-                </v-chip>
-              </template>
+              <v-chip
+                v-if="item.version"
+                small
+                color="light-blue lighten-4"
+                text-color="light-blue darken-3"
+              >
+                <b>{{ item.version }}</b>
+              </v-chip>
+              <v-chip
+                v-else
+                small
+                color="amber lighten-3"
+                text-color="amber darken-4"
+              >
+                <b>DRAFT</b>
+              </v-chip>
               {{ item.meta.dandiset.name }}
             </v-list-item-title>
             <v-list-item-subtitle>

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -16,6 +16,7 @@
         <v-col cols="12">
           <v-list-item-content>
             <v-list-item-title>
+              {{ item.meta.dandiset.name }}
               <v-chip
                 v-if="item.version"
                 small
@@ -32,7 +33,6 @@
               >
                 <b>DRAFT</b>
               </v-chip>
-              {{ item.meta.dandiset.name }}
             </v-list-item-title>
             <v-list-item-subtitle>
               Contact <b>{{ getDandisetContact(item) }}</b>

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -139,15 +139,9 @@ export default {
       if (this.girderDandisetRequest === null || this.publishedVersions === null) {
         return null;
       }
-      const dandisets = [];
-      for (let i = 0; i < this.totalDandisets; i += 1) {
-        if (this.publishedVersions[i]) {
-          dandisets.push(this.publishedVersions[i]);
-        } else {
-          dandisets.push(this.girderDandisetRequest.data[i]);
-        }
-      }
-      return dandisets;
+      return this.girderDandisetRequest.data.map(
+        (dandiset, i) => (this.publishedVersions[i] || dandiset),
+      );
     },
     totalDandisets() {
       return this.girderDandisetRequest ? this.girderDandisetRequest.headers['girder-total-count'] : 0;

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -68,7 +68,7 @@
 <script>
 import DandisetList from '@/components/DandisetList.vue';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
-import { girderRest } from '@/rest';
+import { girderRest, publishRest } from '@/rest';
 
 const DANDISETS_PER_PAGE = 8;
 
@@ -136,14 +136,25 @@ export default {
       return { page, sortOption, sortDir };
     },
     dandisets() {
-      return this.dandisetRequest ? this.dandisetRequest.data : undefined;
+      if (this.girderDandisetRequest === null || this.publishedVersions === null) {
+        return null;
+      }
+      const dandisets = [];
+      for (let i = 0; i < this.totalDandisets; i += 1) {
+        if (this.publishedVersions[i]) {
+          dandisets.push(this.publishedVersions[i]);
+        } else {
+          dandisets.push(this.girderDandisetRequest.data[i]);
+        }
+      }
+      return dandisets;
     },
     totalDandisets() {
-      return this.dandisetRequest ? this.dandisetRequest.headers['girder-total-count'] : 0;
+      return this.girderDandisetRequest ? this.girderDandisetRequest.headers['girder-total-count'] : 0;
     },
   },
   asyncComputed: {
-    async dandisetRequest() {
+    async girderDandisetRequest() {
       const {
         listingUrl, page, sortField, sortDir,
         $route: {
@@ -168,6 +179,16 @@ export default {
       return {
         data, headers, status, statusText,
       };
+    },
+    async publishedVersions() {
+      if (!this.girderDandisetRequest) {
+        return null;
+      }
+      return Promise.all(this.girderDandisetRequest.data.map(
+        async (dandiset) => publishRest.mostRecentVersion(
+          dandiset.meta.dandiset.identifier, dandiset._id,
+        ),
+      ));
     },
   },
   watch: {

--- a/web/src/rest.js
+++ b/web/src/rest.js
@@ -5,8 +5,60 @@ import { RestClient } from '@girder/components/src';
 const apiRoot = process.env.VUE_APP_API_ROOT;
 const publishApiRoot = process.env.VUE_APP_PUBLISH_API_ROOT;
 
+// TODO remove the girderId if we can eliminate the girder ID from the URL
+function girderize(publishedDandiset, girderId) {
+  const { // eslint-disable-next-line camelcase
+    created, updated, dandi_id, version, metadata,
+  } = publishedDandiset;
+  return {
+    _id: girderId,
+    created,
+    updated,
+    version,
+    name: dandi_id,
+    lowerName: dandi_id,
+    meta: metadata,
+  };
+}
+
 const girderRest = new RestClient({ apiRoot, setLocalCookie: true });
 const publishRest = axios.create({ baseURL: publishApiRoot });
+
+Object.assign(publishRest, {
+  async versions(identifier) {
+    try {
+      const response = await publishRest.get(`dandisets/${identifier}/versions/`);
+      return response.data;
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        return [];
+      }
+      throw error;
+    }
+  },
+  async mostRecentVersion(identifier, girderId) {
+    try {
+      const response = await publishRest.get(`dandisets/${identifier}/`);
+      return girderize(response.data, girderId);
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  },
+  async specificVersion(identifier, version, girderId) {
+    try {
+      const response = await publishRest.get(`dandisets/${identifier}/${version}/`);
+      return girderize(response.data, girderId);
+    } catch (error) {
+      if (error.response && error.response.status === 404) {
+        return null;
+      }
+      throw error;
+    }
+  },
+});
 
 const loggedIn = () => !!girderRest.user;
 const user = () => girderRest.user;

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -296,7 +296,7 @@ export default {
       this.meta = { ...val.meta.dandiset };
       this.last_modified = new Date(val.updated).toString();
 
-      this.fetchPublishedVersions(this.meta.identifier);
+      this.versions = await publishRest.versions(this.meta.identifier);
 
       let res = await girderRest.get(`/user/${val.creatorId}`);
       if (res.status === 200) {
@@ -322,18 +322,6 @@ export default {
   methods: {
     publish() {
       girderRest.post(`/dandi/${this.meta.identifier}`);
-    },
-    async fetchPublishedVersions(identifier) {
-      try {
-        const response = await publishRest.get(`dandisets/${identifier}/versions/`);
-        this.versions = response.data;
-      } catch (error) {
-        if (error.response.status === 404) {
-          this.versions = [];
-        } else {
-          throw error;
-        }
-      }
     },
   },
 };


### PR DESCRIPTION
Before displaying a DandisetList, query the publish API to get the most
recently published dandiset. If it exists, display it instead. If it
doesn't exist, display the girder draft as before.

Add some convenience methods to the `publishRest` object.

Fixes #347 

![Screenshot from 2020-05-19 12-44-08](https://user-images.githubusercontent.com/577946/82354212-80b6d580-99ce-11ea-88ff-c3946caf7a88.png)
