### PR TITLE
Fix login redirect bug

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -1,7 +1,5 @@
 <template>
-  <v-app-bar
-    app
-  >
+  <v-app-bar app>
     <v-toolbar-title>
       <v-img
         alt="DANDI logo"
@@ -104,8 +102,8 @@ export default {
   computed: {
     loggedIn,
     returnObject() {
-      const { name, query } = this.$route;
-      return JSON.stringify({ name, query });
+      const { name, query, params } = this.$route;
+      return JSON.stringify({ name, query, params });
     },
   },
 };


### PR DESCRIPTION
When a user that is not logged in views a dandiset, then clicks Log in, the return URL does not record the dandiset they were viewing. Logging in will bounce them back to a blank dandiset page.
Fixes #349