### PR TITLE
Simplify vuetify-xpaths arguments

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -77,11 +77,26 @@ await expect(page).toFillXPath(vTextField('Username'), 'DandiDan');
 await expect(page).toClickXPath(vBtn('Submit'));
 ```
 #### Usage
-The first argument to any `vElement` will generally be the expected contents of the `v-element`.
-* If contents is falsy, like `vFoo()`, the XPath will match any `v-foo`.
-* If contents is a string, like `vFoo('contents')`, the XPath will match any `v-foo` which contains the text `contents`.
-* If contents is a valid XPath, like `vFoo(vBar())`, the XPath will match any `v-foo` which contains a `v-bar`.
+The canonical argument to any `vElement` is a destructured object.
+The arguments are unique to each element, but generally will have a `content` argument and a `cssClass` argument.
+If the argument is not an object, it is assumed to be `content`.
+* If `content` is falsy or absent, like `vFoo()` or `vFoo({content: null})`, the XPath will match any `v-foo`.
+* If `content` is a string, like `vFoo('Hello')` or `vFoo({content: 'World'})`, the XPath will match any `v-foo` which contains the string.
+* If `content` is a valid XPath, like `vFoo(vBar())`, the XPath will match any `v-foo` which contains a `v-bar`.
 Note that `vBar` is not necessarily an immediate child of `vFoo`; `vFoo(vBar())` will also match `<v-foo><div><v-bar /></div></v-foo>`.
+* If `content` is an array, every element in the array is treated as a separate `content`. `vFoo(['Hello', vBar()])` will match any `v-foo` which contains both a `v-bar` element and the text `Hello`.
+
+The same assumptions are generally made for different arguments.
+Here are some examples selectors and DOM elements they will locate:
+```
+vFoo({ contents: vBar('Hello World!'), cssClass: ['world', 'hello'] })
+
+<v-foo class='hello world'>
+  <v-bar>
+    Hello World!
+  </v-bar>
+</v-foo>
+```
 
 The second argument will generally be an object whose options will vary based on the element.
 Most elements have a `cssClass` option which will only match elements with the given class.

--- a/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
+++ b/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
@@ -83,7 +83,7 @@ function elementsAsPredicate(name, values) {
  * @param {*} defaultParam The name of the parameter to use if the argument is not an object.
  */
 function parseArguments(args, defaultParam = 'content') {
-  if (typeof (args) === 'object') {
+  if (typeof args === 'object' && !Array.isArray(args)) {
     return args;
   }
   const ret = {};
@@ -140,7 +140,7 @@ export function vListItemTitle(args) {
 }
 
 export function vTextarea(args) {
-  const { label, cssClass } = parseArguments(args);
+  const { label, cssClass } = parseArguments(args, 'label');
   return `//div${classAsPredicate('v-textarea', cssClass)}//div[label[contains(text(),"${label}")]]//textarea`;
 }
 

--- a/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
+++ b/test/jest-puppeteer-vuetify/src/vuetify-xpaths.js
@@ -69,46 +69,88 @@ function elementsAsPredicate(name, values) {
   return Object.keys(values).map((key) => elementAsPredicate(name, key, values[key])).join('');
 }
 
+/**
+ * Parses the arguments to a XPath generator function.
+ * If the arguments are an object, they are returned as is.
+ * Otherwise, it is assumed that the argument is `content` and it is returned as
+ * `{ content: args }`.
+ * The second argument can optionally be specified by the calling function to change the name of
+ * the default parameter.
+ * For example, `v-icon`s don't have content, so `vIcon` would call `parseArguments(args, 'icon')`.
+ * The result of parsed arguments of `vIcon('text')` would be `{ icon: args }` rather than
+ * `{ content: args }`.
+ * @param {*} args the arguments to parse
+ * @param {*} defaultParam The name of the parameter to use if the argument is not an object.
+ */
+function parseArguments(args, defaultParam = 'content') {
+  if (typeof (args) === 'object') {
+    return args;
+  }
+  const ret = {};
+  ret[defaultParam] = args;
+  return ret;
+}
 
-export function vAvatar(content, { cssClass } = {}) {
+
+export function vAvatar(args) {
+  const { content, cssClass } = parseArguments(args);
   return `//div${classAsPredicate('v-avatar', cssClass)}[span${contentsAsPredicate(content)}]`;
 }
 
-export function vBtn(content, { cssClass } = {}) {
+export function vBtn(args) {
+  const { content, cssClass } = parseArguments(args);
   return `//*${classAsPredicate('v-btn', cssClass)}[span${contentsAsPredicate(content)}]`;
 }
 
-export function vCard(content, { cssClass, title, actions } = {}) {
+export function vCard(args) {
+  const {
+    content,
+    cssClass,
+    title,
+    actions,
+  } = parseArguments(args);
   return `//div${classAsPredicate('v-card', cssClass)}${elementsAsPredicate('v-card', { title, actions })}${contentsAsPredicate(content)}`;
 }
 
-export function vChip(content, { cssClass } = {}) {
+export function vChip(args) {
+  const { content, cssClass } = parseArguments(args);
   return `//*${classAsPredicate('v-chip', cssClass)}[*[@class='v-chip__content']${contentsAsPredicate(content)}]`;
 }
 
-export function vIcon(icon, { cssClass } = {}) {
+export function vIcon(args) {
+  const { icon, cssClass } = parseArguments(args, 'icon');
   return `//*${classAsPredicate('v-icon', icon, cssClass)}`;
 }
 
-export function vListItem(content, { action, title, subtitle } = {}) {
+export function vListItem(args) {
+  const {
+    content,
+    action,
+    title,
+    subtitle,
+  } = parseArguments(args);
   return `//*${classAsPredicate('v-list-item')}${elementsAsPredicate('v-list-item', {
     content, action, title, subtitle,
   })}`;
 }
 
-export function vListItemTitle(content, { cssClass } = {}) {
+export function vListItemTitle(args) {
+  const { content, cssClass } = parseArguments(args);
   return `//div${classAsPredicate('v-list-item__title', cssClass)}${contentsAsPredicate(content)}`;
 }
 
-export function vTextarea(label, { cssClass } = {}) {
+export function vTextarea(args) {
+  const { label, cssClass } = parseArguments(args);
   return `//div${classAsPredicate('v-textarea', cssClass)}//div[label[contains(text(),"${label}")]]//textarea`;
 }
 
-export function vTextField(label, { cssClass } = {}) {
+export function vTextField(args) {
+  const { label, cssClass } = parseArguments(args, 'label');
   const labelPredicate = (label) ? `[.//div[label[contains(text(),"${label}")]]]` : '';
   return `//div${classAsPredicate('v-text-field', cssClass)}${labelPredicate}//input`;
 }
 
-export function vToolbar(content, { cssClass } = {}) {
+export function vToolbar(args) {
+  const { content, cssClass } = parseArguments(args);
   return `//*${classAsPredicate('v-toolbar', cssClass)}[*[@class='v-toolbar__content']${contentsAsPredicate(content)}]`;
 }

--- a/test/src/pages/searchPage.js
+++ b/test/src/pages/searchPage.js
@@ -22,7 +22,7 @@ export async function search(query) {
  * Gets the results currently visible on the search page
  */
 export async function getSearchResults() {
-  const elements = await page.$x(vListItem(null, { title: true, subtitle: true }));
+  const elements = await page.$x(vListItem({ title: true, subtitle: true }));
   return Promise.all(elements.map(async (element) => {
     const name = await element.$eval('.v-list-item__title', (e) => e.innerText);
     const subtitle = await element.$eval('.v-list-item__subtitle', (e) => e.innerText);

--- a/test/src/tests/account.test.js
+++ b/test/src/tests/account.test.js
@@ -35,7 +35,7 @@ describe('account management', () => {
   it('logs the user out', async () => {
     await expect(page).toClickXPath(vAvatar('MR'));
     await page.waitFor(500);
-    await expect(page).toClickXPath(vListItem('Logout', { action: vIcon('mdi-logout') }));
+    await expect(page).toClickXPath(vListItem({ content: 'Logout', action: vIcon('mdi-logout') }));
 
     // this text is only displayed when not logged in
     await expect(page).toMatch('Want to create your own datasets?');

--- a/test/src/tests/registerDandiset.test.js
+++ b/test/src/tests/registerDandiset.test.js
@@ -27,6 +27,6 @@ describe('dandiset registration page', () => {
 
     await expect(page).toClickXPath(vBtn('Register dataset'));
 
-    await expect(page).toContainXPath(vCard(null, { title: [name, vChip('This dataset has not been published!')] }));
+    await expect(page).toContainXPath(vCard({ title: [name, vChip('This dataset has not been published!')] }));
   });
 });


### PR DESCRIPTION
Currently vuetify-xpaths helpers have a clumsy method signature that generally looks like this:
```
function vFoo(content, {cssClass, ...} = {}) {
  ...
}
```
This results in awkward calls like `vFoo(null, {cssClass: '...'});`

The new design assumes that if the argument is an object, it should be destructured as is. Otherwise, the argument `args` will be wrapped in a `{content: args}` object. The magic string `content` can be configured by the different `vFoo` helpers as needed. For instance, `vIcon` will parse the argument `args` to `{icon: args}` instead.