### PR TITLE
Remove testing of "Draft" banner

### DIFF
--- a/test/src/tests/registerDandiset.test.js
+++ b/test/src/tests/registerDandiset.test.js
@@ -26,7 +26,5 @@ describe('dandiset registration page', () => {
     await expect(page).toFillXPath(vTextarea('Description*'), description);
 
     await expect(page).toClickXPath(vBtn('Register dataset'));
-
-    await expect(page).toContainXPath(vCard({ title: [name, vChip('This dataset has not been published!')] }));
   });
 });

--- a/test/src/tests/registerDandiset.test.js
+++ b/test/src/tests/registerDandiset.test.js
@@ -2,8 +2,6 @@ import {
   vBtn,
   vTextField,
   vTextarea,
-  vCard,
-  vChip,
 } from 'jest-puppeteer-vuetify';
 import { CLIENT_URL, uniqueId, registerNewUser } from '../util';
 


### PR DESCRIPTION
This was causing the tests to fail, as this is no longer a valid xpath, as that `v-chip` doesn't exist anymore. This removes that test to allow tests to pass, and for master to be updated, while we think of how to fully update the tests for the DLP.