### PR TITLE
Add check for missing contributors

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -6,6 +6,7 @@
   >
     <template>
       <v-row
+        v-if="contactName"
         no-gutters
         :class="rowClasses"
       >
@@ -137,7 +138,7 @@ export default {
       return this.formatDateTime(this.currentDandiset.updated);
     },
     contactName() {
-      if (!this.currentDandiset) {
+      if (!this.currentDandiset || !this.currentDandiset.meta.dandiset.contributors) {
         return null;
       }
 


### PR DESCRIPTION
This fixes an issue found by @dchiquit, where if the `contributors` field is missing in a dandiset (usually if it's been recently created), the `filter` call in the `contactName` computed prop fails.