### PR TITLE
Add Dandiset Permissions UI

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -109,10 +109,15 @@ class DandiResource(Resource):
         Folder().requireAccess(dandiset, user=self.getCurrentUser(), level=AccessType.ADMIN)
 
         users = []
+        owner_ids = set()
         for owner in owners:
+            if owner["_id"] in owner_ids:
+                continue
+
             if not validate_user(owner):
                 raise ValidationException("All owners must be valid user objects.")
 
+            owner_ids.add(owner["_id"])
             users.append({"id": owner["_id"], "level": AccessType.ADMIN})
 
         # Assumes there is at least one admin

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -108,22 +108,20 @@ class DandiResource(Resource):
         dandiset = find_dandiset_by_identifier(identifier)
         Folder().requireAccess(dandiset, user=self.getCurrentUser(), level=AccessType.ADMIN)
 
-        users = []
-        owner_ids = set()
+        users = {}
         for owner in owners:
-            if owner["_id"] in owner_ids:
+            if owner["_id"] in users:
                 continue
 
             if not validate_user(owner):
                 raise ValidationException("All owners must be valid user objects.")
 
-            owner_ids.add(owner["_id"])
-            users.append({"id": owner["_id"], "level": AccessType.ADMIN})
+            users[owner["_id"]] = {"id": owner["_id"], "level": AccessType.ADMIN}
 
         # Assumes there is at least one admin
         admin = next(User().getAdmins())
         doc = Folder().setAccessList(
-            dandiset, {"users": users}, save=True, recurse=True, user=admin
+            dandiset, {"users": list(users.values())}, save=True, recurse=True, user=admin
         )
         return get_dandiset_owners(doc)
 

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -29,8 +29,7 @@ class DandiResource(Resource):
         self.resourceName = "dandi"
         self.route("GET", (":identifier",), self.get_dandiset)
         self.route("GET", (":identifier", "owners"), self.get_dandiset_owners)
-        self.route("PUT", (":identifier", "owners"), self.add_dandiset_owners)
-        self.route("DELETE", (":identifier", "owners"), self.remove_dandiset_owners)
+        self.route("PUT", (":identifier", "owners"), self.set_dandiset_owners)
         self.route("GET", ("user",), self.get_user_dandisets)
         self.route("GET", ("search",), self.search_dandisets)
         self.route("GET", (), self.list_dandisets)
@@ -95,81 +94,31 @@ class DandiResource(Resource):
 
     @access.user
     @autoDescribeRoute(
-        Description("Add Dandiset Owners")
+        Description("Set Dandiset Owners")
         .param("identifier", "Dandiset Identifier", paramType="path")
         .jsonParam(
             "owners",
-            "A JSON list of girder users to add as owners.",
+            "A JSON list of girder users to set as the owners.",
             paramType="body",
             requireArray=True,
         )
     )
     @dandiset_identifier
-    def add_dandiset_owners(self, identifier, owners, params):
+    def set_dandiset_owners(self, identifier, owners, params):
         dandiset = find_dandiset_by_identifier(identifier)
         Folder().requireAccess(dandiset, user=self.getCurrentUser(), level=AccessType.ADMIN)
 
-        # Make sure the list doesn't contain duplicates
-        # Only work with admin level users, removing non-admins from the ACL
-        # This is done intentionally as a simplifying assumption of providing this API.
-        user_id_to_level = {
-            str(user["id"]): AccessType.ADMIN for user in get_dandiset_owners(dandiset)
-        }
-
+        users = []
         for owner in owners:
             if not validate_user(owner):
                 raise ValidationException("All owners must be valid user objects.")
 
-            user_id_to_level[owner["_id"]] = AccessType.ADMIN
-
-        final_users = [
-            {"id": user_id, "level": level} for user_id, level in user_id_to_level.items()
-        ]
+            users.append({"id": owner["_id"], "level": AccessType.ADMIN})
 
         # Assumes there is at least one admin
         admin = next(User().getAdmins())
         doc = Folder().setAccessList(
-            dandiset, {"users": final_users}, save=True, recurse=True, user=admin
-        )
-        return get_dandiset_owners(doc)
-
-    @access.user
-    @autoDescribeRoute(
-        Description("Remove Dandiset Owners")
-        .param("identifier", "Dandiset Identifier", paramType="path")
-        .jsonParam(
-            "owners",
-            "A JSON list of girder users to remove from owners.",
-            paramType="body",
-            requireArray=True,
-        )
-    )
-    @dandiset_identifier
-    def remove_dandiset_owners(self, identifier, owners, params):
-        dandiset = find_dandiset_by_identifier(identifier)
-        Folder().requireAccess(dandiset, user=self.getCurrentUser(), level=AccessType.ADMIN)
-
-        # Only work with admin level users, removing non-admins from the ACL
-        # This is done intentionally as a simplifying assumption of providing this API.
-        user_id_to_level = {
-            str(user["id"]): AccessType.ADMIN for user in get_dandiset_owners(dandiset)
-        }
-
-        for owner in owners:
-            if not validate_user(owner):
-                raise ValidationException("All owners must be valid user objects.")
-
-            # Prevents a KeyError if owner isn't an existing owner
-            user_id_to_level.pop(owner["_id"], None)
-
-        final_users = [
-            {"id": user_id, "level": level} for user_id, level in user_id_to_level.items()
-        ]
-
-        # Assumes there is at least one admin
-        admin = next(User().getAdmins())
-        doc = Folder().setAccessList(
-            dandiset, {"users": final_users}, save=True, recurse=True, user=admin
+            dandiset, {"users": users}, save=True, recurse=True, user=admin
         )
         return get_dandiset_owners(doc)
 

--- a/web/src/store/girder.js
+++ b/web/src/store/girder.js
@@ -36,6 +36,10 @@ export default {
         }
       }
     },
+    async fetchDandisetOwners({ commit }, identifier) {
+      const { data } = await girderRest.get(`/dandi/${identifier}/owners`);
+      commit('setCurrentDandisetOwners', data);
+    },
     async logout() {
       await girderRest.logout();
     },

--- a/web/src/store/girder.js
+++ b/web/src/store/girder.js
@@ -6,6 +6,7 @@ export default {
     browseLocation: null,
     selected: [],
     currentDandiset: null,
+    currentDandisetOwners: null,
   },
   getters: {
     loggedIn,
@@ -16,6 +17,9 @@ export default {
     },
     setCurrentDandiset(state, dandiset) {
       state.currentDandiset = dandiset;
+    },
+    setCurrentDandisetOwners(state, owners) {
+      state.currentDandisetOwners = owners;
     },
     setBrowseLocation(state, location) {
       state.browseLocation = location;

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -128,9 +128,8 @@
                 </template>
               </v-tooltip>
             </template>
-            <!-- Key set randomly to force re-render of manage dialog -->
             <DandisetOwnersDialog
-              :key="Math.random().toString(36).substring(2)"
+              :key="ownerDialogKey"
               :owners="owners"
               @close="ownerDialog = false"
             />
@@ -213,6 +212,7 @@ export default {
       labelClasses: 'mx-2 text--secondary',
       itemClasses: 'font-weight-medium',
       ownerDialog: false,
+      ownerDialogKey: 0,
     };
   },
   computed: {
@@ -263,6 +263,10 @@ export default {
         const { identifier } = val.meta.dandiset;
         this.fetchDandisetOwners(identifier);
       },
+    },
+    ownerDialog() {
+      // This is incremented to force re-render of the owner dialog
+      this.ownerDialogKey += 1;
     },
   },
   methods: {

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -195,8 +195,8 @@
 </template>
 
 <script>
-import { mapState, mapMutations } from 'vuex';
-import girderRest, { loggedIn, user } from '@/rest';
+import { mapState, mapActions } from 'vuex';
+import { loggedIn, user } from '@/rest';
 import moment from 'moment';
 
 import DandisetOwnersDialog from './DandisetOwnersDialog.vue';
@@ -261,8 +261,7 @@ export default {
       immediate: true,
       async handler(val) {
         const { identifier } = val.meta.dandiset;
-        const { data } = await girderRest.get(`/dandi/${identifier}/owners`);
-        this.setCurrentDandisetOwners(data);
+        this.fetchDandisetOwners(identifier);
       },
     },
   },
@@ -274,7 +273,7 @@ export default {
 
       return `${date} at ${time}`;
     },
-    ...mapMutations('girder', ['setCurrentDandisetOwners']),
+    ...mapActions('girder', ['fetchDandisetOwners']),
   },
 };
 </script>

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -135,14 +135,20 @@
       <v-row :class="rowClasses">
         <v-col cols="12">
           <v-chip
-            v-for="owner in owners"
+            v-for="owner in limitedOwners"
             :key="owner.id"
             color="light-blue lighten-4"
             text-color="light-blue darken-3"
-            class="font-weight-medium mx-1"
+            class="font-weight-medium ma-1"
           >
             {{ owner.login }}
           </v-chip>
+          <span
+            v-if="numExtraOwners"
+            class="ml-1 text--secondary"
+          >
+            +{{ numExtraOwners }} more...
+          </span>
         </v-col>
       </v-row>
       <!-- TODO: Uncomment this once the versions API is accessible -->
@@ -226,16 +232,15 @@ export default {
 
       return null;
     },
+    limitedOwners() {
+      return this.owners.slice(0, 5);
+    },
+    numExtraOwners() {
+      return this.owners.length - this.limitedOwners.length;
+    },
     ...mapState('girder', {
       currentDandiset: (state) => state.currentDandiset,
       owners: (state) => state.currentDandisetOwners,
-      // owners: (state) => [
-      //   ...state.currentDandisetOwners,
-      //   ...state.currentDandisetOwners,
-      //   ...state.currentDandisetOwners,
-      //   ...state.currentDandisetOwners,
-      //   ...state.currentDandisetOwners,
-      // ],
     }),
   },
   watch: {

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -94,21 +94,35 @@
             width="50%"
           >
             <template v-slot:activator="{ on }">
-              <v-btn
-                color="primary"
-                x-small
-                text
-                v-on="on"
+              <v-tooltip
+                :disabled="loggedIn"
+                left
               >
-                <v-icon
-                  x-small
-                  class="pr-1"
+                <template
+                  v-slot:activator="{ on: tooltipOn }"
                 >
-                  mdi-lock
-                </v-icon>
-                Manage
-              </v-btn>
+                  <div v-on="tooltipOn">
+                    <v-btn
+                      color="primary"
+                      x-small
+                      text
+                      :disabled="!loggedIn"
+                      v-on="on"
+                    >
+                      <v-icon
+                        x-small
+                        class="pr-1"
+                      >
+                        mdi-lock
+                      </v-icon>
+                      Manage
+                    </v-btn>
+                  </div>
+                </template>
+                You must be logged in to manage/view permissions.
+              </v-tooltip>
             </template>
+            <!-- Key set randomly to force re-render of manage dialog -->
             <DandisetOwnersDialog
               :key="Math.random().toString(36).substring(2)"
               :owners="owners"
@@ -170,7 +184,7 @@
 
 <script>
 import { mapState, mapMutations } from 'vuex';
-import girderRest from '@/rest';
+import girderRest, { loggedIn } from '@/rest';
 import moment from 'moment';
 
 import DandisetOwnersDialog from './DandisetOwnersDialog.vue';
@@ -190,6 +204,7 @@ export default {
     };
   },
   computed: {
+    loggedIn,
     created() {
       return this.formatDateTime(this.currentDandiset.created);
     },

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -233,9 +233,11 @@ export default {
       return null;
     },
     limitedOwners() {
+      if (!this.owners) return [];
       return this.owners.slice(0, 5);
     },
     numExtraOwners() {
+      if (!this.owners) return 0;
       return this.owners.length - this.limitedOwners.length;
     },
     ...mapState('girder', {

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -96,7 +96,7 @@
           >
             <template v-slot:activator="{ on }">
               <v-tooltip
-                :disabled="loggedIn"
+                :disabled="!manageOwnersDisabled"
                 left
               >
                 <template
@@ -107,7 +107,7 @@
                       color="primary"
                       x-small
                       text
-                      :disabled="!loggedIn"
+                      :disabled="manageOwnersDisabled"
                       v-on="on"
                     >
                       <v-icon
@@ -120,7 +120,12 @@
                     </v-btn>
                   </div>
                 </template>
-                You must be logged in to manage/view permissions.
+                <template v-if="loggedIn">
+                  You must be an owner to manage ownership.
+                </template>
+                <template v-else>
+                  You must be logged in to manage ownership.
+                </template>
               </v-tooltip>
             </template>
             <!-- Key set randomly to force re-render of manage dialog -->
@@ -191,7 +196,7 @@
 
 <script>
 import { mapState, mapMutations } from 'vuex';
-import girderRest, { loggedIn } from '@/rest';
+import girderRest, { loggedIn, user } from '@/rest';
 import moment from 'moment';
 
 import DandisetOwnersDialog from './DandisetOwnersDialog.vue';
@@ -211,6 +216,7 @@ export default {
     };
   },
   computed: {
+    user,
     loggedIn,
     created() {
       return this.formatDateTime(this.currentDandiset.created);
@@ -232,6 +238,10 @@ export default {
       }
 
       return null;
+    },
+    manageOwnersDisabled() {
+      if (!this.loggedIn || !this.owners) return true;
+      return !this.owners.find((owner) => owner.id === this.user._id);
     },
     limitedOwners() {
       if (!this.owners) return [];

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -63,7 +63,7 @@
           </v-col>
           <v-col
             v-if="detailsPanel && !$vuetify.breakpoint.smAndDown"
-            cols="auto"
+            cols="3"
           >
             <DandisetDetails />
           </v-col>

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -17,7 +17,6 @@
           v-model="selection"
           :items="items"
           :loading="loadingUsers"
-          :disabled="editDisabled"
           :search-input.sync="search"
           hide-no-data
           clearable
@@ -76,7 +75,6 @@
         tile
         text
         color="primary"
-        :disabled="editDisabled"
         @click="save"
       >
         Save Changes
@@ -119,10 +117,6 @@ export default {
   },
   computed: {
     user,
-    editDisabled() {
-      if (!this.user) return true;
-      return !this.owners.find((owner) => owner.id === this.user._id);
-    },
     ...mapState('girder', ['currentDandiset']),
   },
   watch: {

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -1,6 +1,6 @@
 <!-- TODO: Find way to clear v-autocomplete once selected-->
 <template>
-  <v-card height="70vh">
+  <v-card class="flex-grow-0">
     <v-card-title>Manage Ownership</v-card-title>
     <template v-if="!owners || !owners.length">
       <v-row
@@ -32,9 +32,9 @@
       <v-row class="mx-1">
         <v-list
           width="100%"
-          height="49vh"
           style="overflow-y: auto;"
           class="px-6"
+          max-height="50vh"
         >
           <template
             v-for="(owner, i) in newOwners"
@@ -62,7 +62,7 @@
     <v-row
       justify="end"
       align="end"
-      class="mx-1 mt-2"
+      class="mx-1 pt-4 pb-2"
     >
       <v-btn
         tile

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -19,6 +19,7 @@
           v-model="selection"
           :items="items"
           :loading="loadingUsers"
+          :disabled="editDisabled"
           :search-input.sync="search"
           hide-no-data
           clearable
@@ -77,6 +78,7 @@
         tile
         text
         color="primary"
+        :disabled="editDisabled"
         @click="save"
       >
         Save Changes
@@ -86,7 +88,7 @@
 </template>
 
 <script>
-import girderRest from '@/rest';
+import girderRest, { user } from '@/rest';
 import { mapState, mapMutations } from 'vuex';
 // import _ from 'lodash';
 // const listToObject = (list) => (list.reduce((acc, owner) => ({ [owner.id]: owner, ...acc }), {}));
@@ -117,6 +119,11 @@ export default {
     };
   },
   computed: {
+    user,
+    editDisabled() {
+      if (!this.user) return true;
+      return !this.owners.find((owner) => owner.id === this.user._id);
+    },
     ...mapState('girder', ['currentDandiset']),
   },
   watch: {

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -1,0 +1,160 @@
+<!-- TODO: Fix card to put buttons at the bottom -->
+<!-- TODO: Make only the v-list scroll, keep height of everything else -->
+<!-- TODO: Find way to clear v-autocomplete once selected-->
+<template>
+  <v-card height="500px">
+    <v-card-title>Manage Ownership</v-card-title>
+    <template v-if="!owners || !owners.length">
+      <v-row
+        align="center"
+        justify="center"
+        class="mx-1"
+      >
+        No owners
+      </v-row>
+    </template>
+    <template v-else>
+      <v-row class="mx-1 px-6">
+        <v-autocomplete
+          v-model="selection"
+          :items="items"
+          :loading="loadingUsers"
+          :search-input.sync="search"
+          hide-no-data
+          clearable
+          auto-select-first
+          item-text="name"
+          placeholder="Search by name or username"
+          solo
+          outlined
+          flat
+          return-object
+        />
+      </v-row>
+      <v-divider />
+      <v-row class="mx-1">
+        <v-list
+          width="100%"
+          height="100%"
+          class="px-6"
+        >
+          <template
+            v-for="(owner, i) in newOwners"
+          >
+            <v-list-item
+              :key="owner._id"
+            >
+              <v-list-item-title>
+                {{ owner.name }} ({{ owner.login }})
+              </v-list-item-title>
+              <v-list-item-action>
+                <v-btn
+                  icon
+                  @click="removeOwner(i)"
+                >
+                  <v-icon>mdi-close</v-icon>
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+            <v-divider :key="`${owner.id}-divider`" />
+          </template>
+        </v-list>
+      </v-row>
+    </template>
+    <v-row
+      justify="end"
+      align="end"
+      class="mx-1"
+    >
+      <v-btn
+        tile
+        text
+        @click="cancel"
+      >
+        Cancel
+      </v-btn>
+      <v-btn
+        tile
+        text
+        color="primary"
+        @click="save"
+      >
+        Save Changes
+      </v-btn>
+    </v-row>
+  </v-card>
+</template>
+
+<script>
+import girderRest from '@/rest';
+import { mapState, mapMutations } from 'vuex';
+// import _ from 'lodash';
+// const listToObject = (list) => (list.reduce((acc, owner) => ({ [owner.id]: owner, ...acc }), {}));
+
+
+const userFormatConversion = (users) => users.map(({
+  _id, _accessLevel, login, firstName, lastName,
+}) => ({
+  id: _id, level: _accessLevel, login, name: `${firstName} ${lastName}`,
+}));
+
+
+export default {
+  name: 'DandisetOwnersDialog',
+  props: {
+    owners: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      search: null,
+      loadingUsers: false,
+      selection: null,
+      newOwners: [...this.owners],
+      items: [],
+    };
+  },
+  computed: {
+    ...mapState('girder', ['currentDandiset']),
+  },
+  watch: {
+    async search(val, oldVal) {
+      if (!this.search || this.loadingUsers || val === oldVal) return;
+
+      this.loadingUsers = true;
+      const { data } = await girderRest.get('/user/', { params: { text: this.search } });
+
+      // Needed to match existing owner document schema
+      this.items = userFormatConversion(data);
+
+      this.loadingUsers = false;
+    },
+    selection(val) {
+      if (!val || this.newOwners.find((x) => x.id === val.id)) return;
+
+      this.newOwners.push(val);
+      this.search = null;
+      this.selection = null;
+    },
+  },
+  methods: {
+    removeOwner(index) {
+      this.newOwners.splice(index, 1);
+    },
+    cancel() {
+      this.$emit('close');
+    },
+    async save() {
+      const { identifier } = this.currentDandiset.meta.dandiset;
+      const formattedOwners = this.newOwners.map((owner) => ({ _id: owner.id }));
+
+      const { data } = await girderRest.put(`/dandi/${identifier}/owners`, formattedOwners);
+      this.setCurrentDandisetOwners(data);
+      this.cancel();
+    },
+    ...mapMutations('girder', ['setCurrentDandisetOwners']),
+  },
+};
+</script>

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -1,8 +1,6 @@
-<!-- TODO: Fix card to put buttons at the bottom -->
-<!-- TODO: Make only the v-list scroll, keep height of everything else -->
 <!-- TODO: Find way to clear v-autocomplete once selected-->
 <template>
-  <v-card height="500px">
+  <v-card height="70vh">
     <v-card-title>Manage Ownership</v-card-title>
     <template v-if="!owners || !owners.length">
       <v-row
@@ -36,7 +34,8 @@
       <v-row class="mx-1">
         <v-list
           width="100%"
-          height="100%"
+          height="49vh"
+          style="overflow-y: auto;"
           class="px-6"
         >
           <template
@@ -65,7 +64,7 @@
     <v-row
       justify="end"
       align="end"
-      class="mx-1"
+      class="mx-1 mt-2"
     >
       <v-btn
         tile

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -67,7 +67,7 @@
       <v-btn
         tile
         text
-        @click="cancel"
+        @click="close"
       >
         Cancel
       </v-btn>
@@ -140,7 +140,7 @@ export default {
     removeOwner(index) {
       this.newOwners.splice(index, 1);
     },
-    cancel() {
+    close() {
       this.$emit('close');
     },
     async save() {
@@ -149,7 +149,7 @@ export default {
 
       const { data } = await girderRest.put(`/dandi/${identifier}/owners`, formattedOwners);
       this.setCurrentDandisetOwners(data);
-      this.cancel();
+      this.close();
     },
     ...mapMutations('girder', ['setCurrentDandisetOwners']),
   },


### PR DESCRIPTION
Adds a UI component for dandiset permissions

This PR also changes the girder endpoint for changing the owners of a dandiset, replacing the add/delete endpoints with a single `set_dandiset_owners` function, which takes the whole list.