### PR TITLE
Add a locking service to girder

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+from girder import events
 from girder.models.folder import Folder
 from girder.models.setting import Setting
 from girder.plugin import GirderPlugin
 from girder.settings import SettingKey
 from girder_user_quota.settings import PluginSettings as UserQuotaPluginSettings
 
+from . import locking
 from .rest import DandiResource
 from .util import DANDISET_IDENTIFIER_COUNTER
 
@@ -28,3 +30,14 @@ class DandiArchivePlugin(GirderPlugin):
         Setting().set(UserQuotaPluginSettings.DEFAULT_USER_QUOTA, 0)
 
         info["apiRoot"].dandi = DandiResource()
+
+        events.bind("model.folder.save", "folder_save_listener", locking.folder_save_listener)
+        # TODO item save
+        # TODO file save
+        events.bind(
+            "model.upload.assetstore",
+            "upload_assetstore_listener",
+            locking.upload_assetstore_listener,
+        )
+        # TODO file delete
+        # TODO file move

--- a/girder-dandi-archive/girder_dandi_archive/__init__.py
+++ b/girder-dandi-archive/girder_dandi_archive/__init__.py
@@ -32,12 +32,13 @@ class DandiArchivePlugin(GirderPlugin):
         info["apiRoot"].dandi = DandiResource()
 
         events.bind("model.folder.save", "folder_save_listener", locking.folder_save_listener)
-        # TODO item save
-        # TODO file save
+        events.bind("model.item.save", "item_save_listener", locking.item_save_listener)
+        events.bind("model.item.remove", "item_remove_listener", locking.item_remove_listener)
         events.bind(
             "model.upload.assetstore",
             "upload_assetstore_listener",
             locking.upload_assetstore_listener,
         )
-        # TODO file delete
+        # TODO file save
+        # TODO file remove
         # TODO file move

--- a/girder-dandi-archive/girder_dandi_archive/locking.py
+++ b/girder-dandi-archive/girder_dandi_archive/locking.py
@@ -13,7 +13,7 @@ def _get_lock(identifier):
     If there is no lock, None is returned.
     """
     dandiset_folder = find_dandiset_by_identifier(identifier)
-    if "locked" not in dandiset_folder:
+    if dandiset_folder is None or "locked" not in dandiset_folder:
         return None
     return str(dandiset_folder["locked"])
 

--- a/girder-dandi-archive/girder_dandi_archive/locking.py
+++ b/girder-dandi-archive/girder_dandi_archive/locking.py
@@ -124,14 +124,14 @@ def folder_save_listener(event):
         pass
 
 
-def _get_dandiset_for_file(resource):
-    """Get the root dandiset folder which the given file belongs to."""
-    if "folderId" not in resource:
+def _get_dandiset_for_item(item):
+    """Get the root dandiset folder which the given item belongs to."""
+    if "folderId" not in item:
         # the resource is top level under a collection, so it can't be in a dandiset
         return None
-    subfolder = Folder().findOne(resource["folderId"])
+    subfolder = Folder().findOne(item["folderId"])
     # Dandisets are always top level folders.
-    # Ascend the file tree until the subfolder is the root collection.
+    # Ascend the file tree until the parent of the subfolder is the root collection.
     # After the loop completes, subfolder will be the dandiset containing the resource.
     while subfolder["parentCollection"] != "collection":
         subfolder = Folder().findOne(subfolder["parentId"])
@@ -146,8 +146,8 @@ def upload_assetstore_listener(event):
     If the root dandiset folder has been locked by someone other than the current user,
     an exception is thrown.
     """
-    resource = event.info["resource"]
-    folder = _get_dandiset_for_file(resource)
+    item = event.info["resource"]
+    folder = _get_dandiset_for_item(item)
     if folder is None:
         return
     identifier = folder["meta"]["dandiset"]["identifier"]
@@ -156,8 +156,8 @@ def upload_assetstore_listener(event):
 
 def item_save_listener(event):
     """Listen to item save events to enforce locking."""
-    resource = event.info
-    folder = _get_dandiset_for_file(resource)
+    item = event.info
+    folder = _get_dandiset_for_item(item)
     if folder is None:
         return
     identifier = folder["meta"]["dandiset"]["identifier"]
@@ -166,8 +166,8 @@ def item_save_listener(event):
 
 def item_remove_listener(event):
     """Listen to item remove events to enforce locking."""
-    resource = event.info
-    folder = _get_dandiset_for_file(resource)
+    item = event.info
+    folder = _get_dandiset_for_item(item)
     if folder is None:
         return
     identifier = folder["meta"]["dandiset"]["identifier"]

--- a/girder-dandi-archive/girder_dandi_archive/locking.py
+++ b/girder-dandi-archive/girder_dandi_archive/locking.py
@@ -126,7 +126,9 @@ def folder_save_listener(event):
 
 def _get_dandiset_for_file(resource):
     """Get the root dandiset folder which the given file belongs to."""
-    # TODO assuming that the file being uploaded is in a folder
+    if "folderId" not in resource:
+        # the resource is top level under a collection, so it can't be in a dandiset
+        return None
     subfolder = Folder().findOne(resource["folderId"])
     # Dandisets are always top level folders.
     # Ascend the file tree until the subfolder is the root collection.
@@ -146,6 +148,8 @@ def upload_assetstore_listener(event):
     """
     resource = event.info["resource"]
     folder = _get_dandiset_for_file(resource)
+    if folder is None:
+        return
     identifier = folder["meta"]["dandiset"]["identifier"]
     require_access(identifier, getCurrentUser())
 
@@ -154,6 +158,8 @@ def item_save_listener(event):
     """Listen to item save events to enforce locking."""
     resource = event.info
     folder = _get_dandiset_for_file(resource)
+    if folder is None:
+        return
     identifier = folder["meta"]["dandiset"]["identifier"]
     require_access(identifier, getCurrentUser())
 
@@ -162,5 +168,7 @@ def item_remove_listener(event):
     """Listen to item remove events to enforce locking."""
     resource = event.info
     folder = _get_dandiset_for_file(resource)
+    if folder is None:
+        return
     identifier = folder["meta"]["dandiset"]["identifier"]
     require_access(identifier, getCurrentUser())

--- a/girder-dandi-archive/girder_dandi_archive/locking.py
+++ b/girder-dandi-archive/girder_dandi_archive/locking.py
@@ -1,0 +1,129 @@
+from girder.api.describe import getCurrentUser
+from girder.constants import AccessType
+from girder.exceptions import AccessException
+from girder.models.folder import Folder
+
+from .util import find_dandiset_by_identifier
+
+
+def _get_lock(identifier):
+    """
+    Return the current owner of the lock on the given dandiset.
+
+    If there is no lock, None is returned.
+    """
+    dandiset_folder = find_dandiset_by_identifier(identifier)
+    if "locked" not in dandiset_folder:
+        return None
+    return str(dandiset_folder["locked"])
+
+
+def _set_lock(identifier, user):
+    """
+    Set the lock on the given dandiset to the given user.
+
+    The user must have admin access on the dandiset.
+    """
+    dandiset_folder = find_dandiset_by_identifier(identifier)
+    Folder().requireAccess(dandiset_folder, user=user, level=AccessType.ADMIN)
+    dandiset_folder["locked"] = user["_id"]
+    Folder().save(dandiset_folder)
+
+
+def _remove_lock(identifier):
+    """Remove the lock from the dandiset if it is present."""
+    dandiset_folder = find_dandiset_by_identifier(identifier)
+    if "locked" in dandiset_folder:
+        del dandiset_folder["locked"]
+        Folder().save(dandiset_folder)
+
+
+def has_lock(identifier, user):
+    """
+    Return whether or not the given user currently owns the lock on the given dandiset.
+
+    If user is None, returns whether or not there is no lock on the given dandiset.
+    """
+    user_id = str(user["_id"]) if user is not None else None
+    return _get_lock(identifier) == user_id
+
+
+def require_lock(identifier, user):
+    """
+    Require that the user has the lock on the given dandiset.
+
+    If user is None, then it will verify that there is no lock.
+    This method should be used to ensure that a lock is present.
+    Note the different between this method and require_access.
+    """
+    if not has_lock(identifier, user):
+        locked_by = _get_lock(identifier)
+        if locked_by is not None:
+            raise AccessException(f"Dandiset {identifier} is currently locked by {locked_by}")
+        else:
+            raise AccessException(f"Dandiset {identifier} is currently unlocked")
+
+
+def require_access(identifier, user):
+    """
+    Require that the user either have the lock, or no lock is present.
+
+    This method should be used to determine if a user can modify a dandiset.
+    """
+    if (not has_lock(identifier, None)) and (not has_lock(identifier, user)):
+        locked_by = _get_lock(identifier)
+        raise AccessException(f"Dandiset {identifier} is currently locked by {locked_by}")
+
+
+def lock(identifier, user):
+    """
+    Lock the given dandiset to the given user.
+
+    The dandiset must be unlocked.
+    """
+    require_lock(identifier, None)
+    _set_lock(identifier, user)
+
+
+def unlock(identifier, user):
+    """
+    Unlock the given dandiset.
+
+    The given user must currently have the lock on the dandiset.
+    """
+    require_lock(identifier, user)
+    _remove_lock(identifier)
+
+
+def folder_save_listener(event):
+    """
+    Listen to folder save events to enforce locking.
+
+    If the folder has been locked by someone other than the current user,
+    an exception is thrown.
+    """
+    try:
+        identifier = event.info["meta"]["dandiset"]["identifier"]
+        require_access(identifier, getCurrentUser())
+    except KeyError:
+        # This event is on a non-dandiset folder, no locking is required
+        pass
+
+
+def upload_assetstore_listener(event):
+    """
+    Listen to upload assetstore events to enforce locking.
+
+    These events occur before files are uploaded.
+    If the root dandiset folder has been locked by someone other than the current user,
+    an exception is thrown.
+    """
+    thing = event.info["resource"]
+    while thing["parentCollection"] != "collection":
+        thing = Folder().findOne(thing["parentId"])
+    try:
+        identifier = thing["meta"]["dandiset"]["identifier"]
+        require_access(identifier, getCurrentUser())
+    except KeyError:
+        # This event is on a non-dandiset folder, no locking is required
+        pass

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -45,6 +45,7 @@ class DandiResource(Resource):
         self.route("GET", ("stats",), self.stats)
         self.route("POST", (":identifier", "lock"), self.lock_dandiset)
         self.route("POST", (":identifier", "unlock"), self.unlock_dandiset)
+        self.route("GET", (":identifier", "lock", "owner"), self.get_dandiset_lock_owner)
         # TODO add a way for admins to remove dead locks
 
     @access.user(scope=TokenScope.DATA_WRITE)
@@ -348,3 +349,17 @@ class DandiResource(Resource):
     @dandiset_identifier
     def unlock_dandiset(self, identifier, params):
         locking.unlock(identifier, self.getCurrentUser())
+
+    @access.public
+    @autoDescribeRoute(
+        Description("The owner of the lock on a Dandiset").param(
+            "identifier", "Dandiset Identifier", paramType="path"
+        )
+    )
+    @dandiset_identifier
+    def get_dandiset_lock_owner(self, identifier, params):
+        owner = locking.get_lock_owner(identifier)
+        if owner is None:
+            return
+        print("lock owned by", owner)
+        return {key: owner[key] for key in ("firstName", "lastName", "email")}

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -360,6 +360,5 @@ class DandiResource(Resource):
     def get_dandiset_lock_owner(self, identifier, params):
         owner = locking.get_lock_owner(identifier)
         if owner is None:
-            return
-        print("lock owned by", owner)
+            return None
         return {key: owner[key] for key in ("firstName", "lastName", "email")}

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -14,6 +14,7 @@ from girder.models.folder import Folder
 from girder.models.setting import Setting
 from girder.models.user import User
 
+from . import locking
 from .settings import PUBLISH_API_KEY, PUBLISH_API_URL
 from .util import (
     dandiset_find,
@@ -42,6 +43,9 @@ class DandiResource(Resource):
         self.route("POST", (), self.create_dandiset)
         self.route("POST", (":identifier",), self.publish_dandiset)
         self.route("GET", ("stats",), self.stats)
+        self.route("POST", (":identifier", "lock"), self.lock_dandiset)
+        self.route("POST", (":identifier", "unlock"), self.unlock_dandiset)
+        # TODO add a way for admins to remove dead locks
 
     @access.user(scope=TokenScope.DATA_WRITE)
     @describeRoute(
@@ -244,7 +248,7 @@ class DandiResource(Resource):
     @dandiset_identifier
     def publish_dandiset(self, identifier, params):
         dandiset_folder = find_dandiset_by_identifier(identifier)
-        Folder().requireAccess(dandiset_folder, user=self.getCurrentUser(), level=AccessType.ADMIN),
+        Folder().requireAccess(dandiset_folder, user=self.getCurrentUser(), level=AccessType.ADMIN)
 
         publish_api_url = Setting().get(PUBLISH_API_URL)
         publish_api_key = Setting().get(PUBLISH_API_KEY)
@@ -326,3 +330,21 @@ class DandiResource(Resource):
             "cell_count": cell_count,
             "size": drafts["size"],
         }
+
+    @access.user
+    @autoDescribeRoute(
+        Description("Lock a Dandiset").param("identifier", "Dandiset Identifier", paramType="path")
+    )
+    @dandiset_identifier
+    def lock_dandiset(self, identifier, params):
+        locking.lock(identifier, self.getCurrentUser())
+
+    @access.user
+    @autoDescribeRoute(
+        Description("Unlock a Dandiset").param(
+            "identifier", "Dandiset Identifier", paramType="path"
+        )
+    )
+    @dandiset_identifier
+    def unlock_dandiset(self, identifier, params):
+        locking.unlock(identifier, self.getCurrentUser())


### PR DESCRIPTION
Add two endpoints, `dandi/:identifier/lock` and
`dandi/:identifier/unlock`. These will lock or unlock dandisets for the
current user. When unlocked, a dandiset can be modified by anyone with
permission. When locked, a dandiset can be modified only by the person
who owns the lock.

Locks are enforced using event listeners on folder save and assetstore
upload events. Modifying a dandiset's metadata or uploading new files to
it will fail if another user has locked the dandiset.

The current lock status is stored in a property on the root folder
model. We may eventually want to add an endpoint to return the current
lock status so it can be displayed in the web client.