### PR TITLE
Add initial content browser for published dandisets

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -7,7 +7,7 @@
       v-for="(item, i) in items"
       :key="item._id"
       selectable
-      :to="{ name: 'dandisetLanding', params: { id: item._id, origin } }"
+      :to="{ name: 'dandisetLanding', params: { identifier: item.meta.dandiset.identifier, origin } }"
     >
       <v-row
         no-gutters

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -7,7 +7,10 @@
       v-for="(item, i) in items"
       :key="item._id"
       selectable
-      :to="{ name: 'dandisetLanding', params: { identifier: item.meta.dandiset.identifier, origin } }"
+      :to="{
+        name: 'dandisetLanding',
+        params: { identifier: item.meta.dandiset.identifier, origin }
+      }"
     >
       <v-row
         no-gutters

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -21,11 +21,6 @@ export default new Router({
       component: HomeView,
     },
     {
-      path: '/file-browser/:_modelType?/:_id?',
-      name: 'file-browser',
-      component: FileBrowser,
-    },
-    {
       path: '/user/login',
       name: 'userLogin',
       component: UserLoginView,
@@ -56,7 +51,13 @@ export default new Router({
       component: CreateDandisetView,
     },
     {
-      path: '/dandiset/:id/:version?',
+      path: '/dandiset/:identifier/:version/files',
+      name: 'fileBrowser',
+      props: true,
+      component: FileBrowser,
+    },
+    {
+      path: '/dandiset/:identifier/:version?',
       name: 'dandisetLanding',
       props: true,
       component: DandisetLandingView,

--- a/web/src/store/dandiset.js
+++ b/web/src/store/dandiset.js
@@ -1,4 +1,5 @@
 import { girderRest, publishRest } from '@/rest';
+import { draftVersion } from '@/utils';
 
 export default {
   namespaced: true,
@@ -7,6 +8,11 @@ export default {
     girderDandiset: null,
     loading: false,
     owners: null,
+  },
+  getters: {
+    version(state) {
+      return state.publishDandiset ? state.publishDandiset.version : draftVersion;
+    },
   },
   mutations: {
     setGirderDandiset(state, dandiset) {
@@ -28,10 +34,10 @@ export default {
 
       state.loading = false;
     },
-    async fetchGirderDandiset({ state, commit }, { girderId }) {
+    async fetchGirderDandiset({ state, commit }, { identifier }) {
       state.loading = true;
 
-      const { data } = await girderRest.get(`folder/${girderId}`);
+      const { data } = await girderRest.get(`dandi/${identifier}`);
       commit('setGirderDandiset', data);
 
       state.loading = false;

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -2,8 +2,8 @@ const dandiUrl = 'https://dandiarchive.org';
 const dandiAboutUrl = 'https://dandiarchive.org/about';
 
 function getLocationFromRoute(route) {
-  const { _modelType, _id } = route.params;
-  if (_modelType) {
+  const { _modelType, _id } = route.query;
+  if (_modelType && _id) {
     return { _modelType, _id };
   }
   return null;

--- a/web/src/views/CreateDandisetView/CreateDandisetView.vue
+++ b/web/src/views/CreateDandisetView/CreateDandisetView.vue
@@ -70,9 +70,11 @@ export default {
         },
       });
 
+
+      const { identifier } = data.meta.dandiset;
       this.$router.push({
         name: 'dandisetLanding',
-        params: { id: data._id },
+        params: { identifier },
       });
     },
   },

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -227,7 +227,7 @@
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex';
+import { mapState, mapActions, mapGetters } from 'vuex';
 import {
   loggedIn, user, girderRest, publishRest,
 } from '@/rest';
@@ -277,12 +277,6 @@ export default {
 
       return null;
     },
-    currentVersion() {
-      const { publishDandiset } = this;
-
-      if (publishDandiset) return publishDandiset.version;
-      return draftVersion;
-    },
     currentDandiset() {
       // Done this way because we'll want to add in
       // fetching stats from the publish endpoint later on.
@@ -311,6 +305,9 @@ export default {
       girderDandiset: (state) => state.girderDandiset,
       publishDandiset: (state) => state.publishDandiset,
       owners: (state) => state.owners,
+    }),
+    ...mapGetters('dandiset', {
+      currentVersion: 'version',
     }),
   },
   asyncComputed: {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -158,9 +158,7 @@ export default {
     identifier: {
       immediate: true,
       async handler(identifier) {
-        if (!this.girderDandiset) {
-          this.$store.dispatch('dandiset/fetchGirderDandiset', { identifier });
-        }
+        this.$store.dispatch('dandiset/fetchGirderDandiset', { identifier });
       },
     },
     girderDandiset: {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -97,7 +97,7 @@ export default {
     DandisetDetails,
   },
   props: {
-    id: {
+    identifier: {
       type: String,
       required: true,
     },
@@ -155,14 +155,11 @@ export default {
     }),
   },
   watch: {
-    id: {
+    identifier: {
       immediate: true,
-      async handler(value) {
-        // If we ever change the URL to contain the dandiset ID instead of the
-        // girder folder ID, this should be moved into the store
-
-        if (!this.girderDandiset || !this.meta.length) {
-          this.$store.dispatch('dandiset/fetchGirderDandiset', { girderId: value });
+      async handler(identifier) {
+        if (!this.girderDandiset) {
+          this.$store.dispatch('dandiset/fetchGirderDandiset', { identifier });
         }
       },
     },

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -106,7 +106,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 
 import { dandiUrl } from '@/utils';
 import { girderRest, loggedIn, user } from '@/rest';
@@ -156,10 +156,10 @@ export default {
       return null;
     },
     fileBrowserLink() {
-      if (!this.girderDandiset) return null;
+      const { version } = this;
+      const { identifier } = this.girderDandiset.meta.dandiset;
 
-      const { _modelType, _id } = this.girderDandiset;
-      return { name: 'file-browser', params: { _modelType, _id } };
+      return { name: 'fileBrowser', params: { identifier, version } };
     },
     permalink() {
       return `${dandiUrl}/dandiset/${this.meta.identifier}/draft`;
@@ -175,6 +175,7 @@ export default {
       girderDandiset: (state) => state.girderDandiset,
       publishDandiset: (state) => state.publishDandiset,
     }),
+    ...mapGetters('dandiset', ['version']),
   },
   methods: {
     async publish() {

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -1,158 +1,62 @@
 <template>
-  <v-container style="height: 100%;">
-    <v-row v-if="selected">
-      <v-col :cols="selected.length ? 8 : 12">
-        <girder-file-manager
-          ref="girderFileManager"
-          selectable
-          root-location-disabled
-          :location.sync="location"
-          :value="selected"
-          :initial-items-per-page="25"
-          :items-per-page-options="[10,25,50,100,-1]"
-          @input="setSelected"
-        >
-          <template
-            v-if="isDandiset"
-            v-slot:headerwidget
-          >
-            <v-btn
-              icon
-              color="primary"
-              :to="{ name: 'dandisetLanding', params: { id: location._id }}"
-            >
-              <v-icon>mdi-eye</v-icon>
-            </v-btn>
-          </template>
-        </girder-file-manager>
-      </v-col>
-      <v-col
-        v-if="selected.length"
-        cols="4"
-      >
-        <girder-data-details
-          :value="selected"
-          :action-keys="actions"
-          @action="handleAction"
-        />
-      </v-col>
-    </v-row>
-  </v-container>
+  <v-progress-linear
+    v-if="!girderDandiset"
+    indeterminate
+  />
+  <PublishFileBrowser
+    v-else-if="isPublishedVersion(version)"
+    :identifier="identifier"
+    :version="version"
+  />
+  <GirderFileBrowser
+    v-else
+    :identifier="identifier"
+    :version="version"
+  />
 </template>
 
 <script>
-import {
-  mapGetters,
-  mapMutations,
-  mapState,
-  mapActions,
-} from 'vuex';
-import { DataDetails as GirderDataDetails } from '@girder/components/src/components';
-import { DefaultActionKeys } from '@girder/components/src/components/DataDetails.vue';
-import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+import { mapState, mapActions } from 'vuex';
+import { draftVersion, isPublishedVersion } from '@/utils';
+import GirderFileBrowser from './GirderFileBrowser.vue';
+import PublishFileBrowser from './PublishFileBrowser.vue';
 
-import {
-  getLocationFromRoute,
-} from '@/utils';
-
-// redirect to "Open JupyterLab"
-const JUPYTER_ROOT = 'https://hub.dandiarchive.org';
-
-const actionKeys = [
-  {
-    for: ['item'],
-    name: 'Open JupyterLab',
-    icon: 'mdi-language-python',
-    color: 'primary',
-    generateHref() {
-      return JUPYTER_ROOT;
-    },
-    target: '_blank',
-  },
-  // Download for items only
-  DefaultActionKeys[1],
-];
 
 export default {
-  components: { GirderDataDetails, GirderFileManager },
+  name: 'FileBrowser',
+  components: {
+    GirderFileBrowser,
+    PublishFileBrowser,
+  },
+  props: {
+    identifier: {
+      type: String,
+      required: true,
+    },
+    version: {
+      type: String,
+      required: true,
+    },
+  },
   computed: {
-    isDandiset() {
-      return !!(this.location && this.location.meta && this.location.meta.dandiset);
-    },
-    actions() {
-      const actions = [...actionKeys];
-      const canDelete = (resource) => (
-        (resource._modelType === 'folder' && resource._accessLevel === 2)
-        || (resource._modelType === 'item' && this.location._accessLevel === 2)
-      );
-
-      if (
-        this.selected.length === 1
-        && this.selected[0].meta
-        && this.selected[0].meta.dandiset
-      ) {
-        const id = this.selected[0]._id;
-
-        actions.push({
-          for: ['folder'],
-          name: 'View DANDI Metadata',
-          icon: 'mdi-pencil',
-          color: 'primary',
-          handler() {
-            // eslint-disable-next-line
-              this.$router.push({
-              name: 'dandiset-metadata-viewer',
-              params: { id },
-            });
-          },
-        });
-      }
-
-      if (this.selected.every((item) => canDelete(item))) {
-        actions.push(DefaultActionKeys[3]);
-      }
-
-      return actions;
-    },
-    location: {
-      get() {
-        return this.$store.state.girder.browseLocation;
-      },
-      set(value) {
-        this.setBrowseLocation(value);
-      },
-    },
-    ...mapState('girder', ['selected']),
-    ...mapGetters('girder', ['loggedIn']),
+    ...mapState('dandiset', ['publishDandiset', 'girderDandiset']),
   },
-  watch: {
-    location(newValue) {
-      const { _modelType, _id } = this.$route.params;
+  async created() {
+    // Don't extract girderDandiset or publishDandiset, for reactivity
+    const { identifier, version } = this;
 
-      if (newValue._modelType !== _modelType || newValue._id !== _id) {
-        this.$router.push({ name: 'file-browser', params: { _modelType: newValue._modelType, _id: newValue._id } });
-      }
-    },
-  },
-  created() {
-    const location = getLocationFromRoute(this.$route);
-    this.setBrowseLocation(location);
-    this.fetchFullLocation(location);
+    if (!this.girderDandiset) {
+      // Await so we can use this value afterwards
+      await this.fetchGirderDandiset({ identifier });
+    }
+
+    if (!this.publishDandiset && version !== draftVersion) {
+      this.fetchPublishDandiset({ identifier, version, girderId: this.girderDandiset._id });
+    }
   },
   methods: {
-    async handleAction(action) {
-      if (action.name === 'Delete') {
-        await this.$refs.girderFileManager.refresh();
-        this.setSelected([]);
-      }
-    },
-    ...mapMutations('girder', ['setBrowseLocation', 'setSelected']),
-    ...mapActions('girder', ['fetchFullLocation']),
+    isPublishedVersion,
+    ...mapActions('dandiset', ['fetchPublishDandiset', 'fetchGirderDandiset']),
   },
 };
 </script>
-<style>
-.girder-file-browser .secondary .row .spacer {
-  display: none;
-}
-</style>

--- a/web/src/views/FileBrowserView/GirderFileBrowser.vue
+++ b/web/src/views/FileBrowserView/GirderFileBrowser.vue
@@ -1,0 +1,193 @@
+<template>
+  <v-container style="height: 100%;">
+    <v-row v-if="selected">
+      <v-col :cols="selected.length ? 8 : 12">
+        <girder-file-manager
+          ref="girderFileManager"
+          selectable
+          root-location-disabled
+          :location.sync="location"
+          :value="selected"
+          :initial-items-per-page="25"
+          :items-per-page-options="[10,25,50,100,-1]"
+          @input="setSelected"
+        >
+          <template
+            v-if="isDandiset"
+            v-slot:headerwidget
+          >
+            <v-btn
+              icon
+              color="primary"
+              :to="{
+                name: 'dandisetLanding',
+                params: { identifier: location.meta.dandiset.identifier },
+              }"
+            >
+              <v-icon>mdi-eye</v-icon>
+            </v-btn>
+          </template>
+        </girder-file-manager>
+      </v-col>
+      <v-col
+        v-if="selected.length"
+        cols="4"
+      >
+        <girder-data-details
+          :value="selected"
+          :action-keys="actions"
+          @action="handleAction"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import {
+  mapGetters,
+  mapMutations,
+  mapState,
+  mapActions,
+} from 'vuex';
+import { DataDetails as GirderDataDetails } from '@girder/components/src/components';
+import { DefaultActionKeys } from '@girder/components/src/components/DataDetails.vue';
+import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+
+import {
+  getLocationFromRoute,
+} from '@/utils';
+
+// redirect to "Open JupyterLab"
+const JUPYTER_ROOT = 'https://hub.dandiarchive.org';
+
+const actionKeys = [
+  {
+    for: ['item'],
+    name: 'Open JupyterLab',
+    icon: 'mdi-language-python',
+    color: 'primary',
+    generateHref() {
+      return JUPYTER_ROOT;
+    },
+    target: '_blank',
+  },
+  // Download for items only
+  DefaultActionKeys[1],
+];
+
+export default {
+  name: 'GirderFileBrowser',
+  components: { GirderDataDetails, GirderFileManager },
+  props: {
+    identifier: {
+      type: String,
+      required: true,
+    },
+    version: {
+      type: String,
+      required: true,
+    },
+  },
+  computed: {
+    isDandiset() {
+      return !!(this.location && this.location.meta && this.location.meta.dandiset);
+    },
+    actions() {
+      const actions = [...actionKeys];
+      const canDelete = (resource) => (
+        (resource._modelType === 'folder' && resource._accessLevel === 2)
+        || (resource._modelType === 'item' && this.location._accessLevel === 2)
+      );
+
+      if (
+        this.selected.length === 1
+        && this.selected[0].meta
+        && this.selected[0].meta.dandiset
+      ) {
+        const id = this.selected[0]._id;
+
+        actions.push({
+          for: ['folder'],
+          name: 'View DANDI Metadata',
+          icon: 'mdi-pencil',
+          color: 'primary',
+          handler() {
+            // eslint-disable-next-line
+              this.$router.push({
+              name: 'dandiset-metadata-viewer',
+              params: { id },
+            });
+          },
+        });
+      }
+
+      if (this.selected.every((item) => canDelete(item))) {
+        actions.push(DefaultActionKeys[3]);
+      }
+
+      return actions;
+    },
+    location: {
+      get() {
+        return this.$store.state.girder.browseLocation;
+      },
+      set(value) {
+        this.setBrowseLocation(value);
+      },
+    },
+    ...mapState('dandiset', ['girderDandiset']),
+    ...mapState('girder', ['selected']),
+    ...mapGetters('girder', ['loggedIn']),
+  },
+  watch: {
+    location(newValue) {
+      // Reflects updates from the girder-file-manager into the URL
+      const { _modelType, _id } = newValue;
+      const { _modelType: routeModelType, _id: routeId } = this.$route.query;
+
+      if (_modelType !== routeModelType || _id !== routeId) {
+        const newQuery = {
+          ...this.$route.query,
+          _id,
+          _modelType,
+        };
+
+        const newRoute = {
+          ...this.$route,
+          query: newQuery,
+        };
+
+        this.$router.replace(newRoute);
+      }
+    },
+    identifier(identifier) {
+      this.fetchGirderDandiset({ identifier });
+    },
+  },
+  created() {
+    // girderDandiset ensured to exist by parent FileBrowser component
+    const { _id } = this.girderDandiset;
+
+    const location = getLocationFromRoute(this.$route) || { _modelType: 'folder', _id };
+    this.setBrowseLocation(location);
+    this.fetchFullLocation(location);
+  },
+  methods: {
+    async handleAction(action) {
+      if (action.name === 'Delete') {
+        await this.$refs.girderFileManager.refresh();
+        this.setSelected([]);
+      }
+    },
+    ...mapMutations('girder', ['setBrowseLocation', 'setSelected']),
+    ...mapActions('girder', ['fetchFullLocation']),
+    ...mapActions('dandiset', ['fetchGirderDandiset']),
+  },
+};
+</script>
+<style>
+.girder-file-browser .secondary .row .spacer {
+  display: none;
+}
+</style>

--- a/web/src/views/FileBrowserView/GirderFileBrowser.vue
+++ b/web/src/views/FileBrowserView/GirderFileBrowser.vue
@@ -18,6 +18,7 @@
           >
             <v-btn
               icon
+              exact
               color="primary"
               :to="{
                 name: 'dandisetLanding',

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -1,105 +1,95 @@
 <template>
   <v-container>
-    <v-row v-if="selected">
-      <v-col :cols="selected.length ? 8 : 12">
-        <girder-file-manager
-          ref="girderFileManager"
-          selectable
-          root-location-disabled
-          :location.sync="location"
-          :value="selected"
-          :initial-items-per-page="25"
-          :items-per-page-options="[10,25,50,100,-1]"
-          @input="setSelected"
+    <v-row>
+      <v-col :cols="12">
+        <v-data-table
+          :items="items"
+          :headers="headers"
+          hide-default-header
+          item-key="name"
+          selectable-key="folder"
+          @click:row="selectPath"
         >
-          <template
-            v-if="isDandiset"
-            v-slot:headerwidget
-          >
-            <v-btn
-              icon
-              color="primary"
-              :to="{ name: 'dandisetLanding', params: { identifier: location.meta.dandiset.identifier }}"
-            >
-              <v-icon>mdi-eye</v-icon>
-            </v-btn>
+          <template v-slot:header>
+            {{ location }}
           </template>
-        </girder-file-manager>
-      </v-col>
-      <v-col
-        v-if="selected.length"
-        cols="4"
-      >
-        <girder-data-details
-          :value="selected"
-          :action-keys="actions"
-          @action="handleAction"
-        />
+
+        <!-- <template v-slot:item="{ item }">
+          <v-row>
+            <v-icon>mdi-folder</v-icon>
+            <span>{{ item.name }}</span>
+          </v-row>
+        </template> -->
+        </v-data-table>
       </v-col>
     </v-row>
   </v-container>
 </template>
 
 <script>
-import {
-  mapGetters,
-  mapMutations,
-  mapState,
-  mapActions,
-} from 'vuex';
-import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+import { mapState } from 'vuex';
+import { publishRest } from '@/rest';
 
-import {
-  getLocationFromRoute,
-} from '@/utils';
-
+const isFolder = (pathName) => (pathName.slice(-1) === '/');
+const parentDirectory = '..';
 
 export default {
   name: 'PublishFileBrowser',
-  components: { GirderFileManager },
+  props: {
+    identifier: {
+      type: String,
+      required: true,
+    },
+    version: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      location: '/',
+      // items: [],
+      headers: [
+        {
+          text: 'Name',
+          value: 'name',
+          align: 'start',
+        },
+      ],
+    };
+  },
   computed: {
-    isDandiset() {
-      return !!(this.location && this.location.meta && this.location.meta.dandiset);
-    },
-    location: {
-      get() {
-        return this.$store.state.girder.browseLocation;
-      },
-      set(value) {
-        this.setBrowseLocation(value);
-      },
-    },
-    ...mapState('girder', ['selected']),
-    ...mapGetters('girder', ['loggedIn']),
+    ...mapState('dandiset', ['publishDandiset']),
   },
-  watch: {
-    location(newValue) {
-      const { _modelType, _id } = this.$route.params;
+  asyncComputed: {
+    items: {
+      async get() {
+        const { version, identifier, location } = this;
+        const { data } = await publishRest.get(`dandisets/${identifier}/versions/${version}/assets/paths/`, {
+          params: {
+            path_prefix: location,
+          },
+        });
 
-      if (newValue._modelType !== _modelType || newValue._id !== _id) {
-        this.$router.push({ name: 'file-browser', params: { _modelType: newValue._modelType, _id: newValue._id } });
-      }
+        const mapped = data.map((x) => ({ name: x, folder: isFolder(x) }));
+        return [
+          { name: parentDirectory, folder: true },
+          ...mapped,
+        ];
+      },
+      default: [],
     },
   },
-  created() {
-    const location = getLocationFromRoute(this.$route);
-    this.setBrowseLocation(location);
-    this.fetchFullLocation(location);
-  },
+  watch: {},
+  created() {},
   methods: {
-    async handleAction(action) {
-      if (action.name === 'Delete') {
-        await this.$refs.girderFileManager.refresh();
-        this.setSelected([]);
+    selectPath({ name }) {
+      if (name === parentDirectory) {
+        this.location = `${this.location.split('/').slice(0, -2).join('/')}/`;
+      } else {
+        this.location = `${this.location}${name}`;
       }
     },
-    ...mapMutations('girder', ['setBrowseLocation', 'setSelected']),
-    ...mapActions('girder', ['fetchFullLocation']),
   },
 };
 </script>
-<style>
-.girder-file-browser .secondary .row .spacer {
-  display: none;
-}
-</style>

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -12,7 +12,7 @@
                 params: { identifier },
               }"
             >
-              <v-icon>mdi-home</v-icon>
+              <v-icon>mdi-jellyfish</v-icon>
             </v-btn>
             <v-divider
               vertical

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -122,9 +122,12 @@ export default {
         this.location = rootDirectory;
       }
     },
-  },
-  created() {
-    this.location = this.$route.query.location || rootDirectory;
+    $route: {
+      immediate: true,
+      handler(route) {
+        this.location = route.query.location || rootDirectory;
+      },
+    },
   },
   methods: {
     selectPath(item) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -18,7 +18,26 @@
               vertical
               class="ml-2 mr-3"
             />
-            {{ location }}
+            <router-link
+              :to="{ name: 'fileBrowser', query: { location: rootDirectory } }"
+              style="text-decoration: none;"
+            >
+              {{ rootDirectory }}
+            </router-link>
+
+            <template v-for="(part, i) in splitLocation">
+              <template v-if="part">
+                <router-link
+                  :key="part"
+                  :to="{ name: 'fileBrowser', query: { location: locationSlice(i) } }"
+                  style="text-decoration: none;"
+                  class="mx-2"
+                >
+                  {{ part }}
+                </router-link>
+                {{ i === splitLocation.length - 1 ? '' : '/' }}
+              </template>
+            </template>
           </v-card-title>
           <v-progress-linear
             v-if="loading"
@@ -74,11 +93,15 @@ export default {
   },
   data() {
     return {
+      rootDirectory,
       location: rootDirectory,
       loading: false,
     };
   },
   computed: {
+    splitLocation() {
+      return this.location.split('/');
+    },
     ...mapState('dandiset', ['publishDandiset']),
   },
   asyncComputed: {
@@ -130,6 +153,9 @@ export default {
     },
   },
   methods: {
+    locationSlice(index) {
+      return `${this.splitLocation.slice(0, index + 1).join('/')}/`;
+    },
     selectPath(item) {
       const { name, folder } = item;
 

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -1,0 +1,105 @@
+<template>
+  <v-container>
+    <v-row v-if="selected">
+      <v-col :cols="selected.length ? 8 : 12">
+        <girder-file-manager
+          ref="girderFileManager"
+          selectable
+          root-location-disabled
+          :location.sync="location"
+          :value="selected"
+          :initial-items-per-page="25"
+          :items-per-page-options="[10,25,50,100,-1]"
+          @input="setSelected"
+        >
+          <template
+            v-if="isDandiset"
+            v-slot:headerwidget
+          >
+            <v-btn
+              icon
+              color="primary"
+              :to="{ name: 'dandisetLanding', params: { identifier: location.meta.dandiset.identifier }}"
+            >
+              <v-icon>mdi-eye</v-icon>
+            </v-btn>
+          </template>
+        </girder-file-manager>
+      </v-col>
+      <v-col
+        v-if="selected.length"
+        cols="4"
+      >
+        <girder-data-details
+          :value="selected"
+          :action-keys="actions"
+          @action="handleAction"
+        />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import {
+  mapGetters,
+  mapMutations,
+  mapState,
+  mapActions,
+} from 'vuex';
+import { FileManager as GirderFileManager } from '@girder/components/src/components/Snippet';
+
+import {
+  getLocationFromRoute,
+} from '@/utils';
+
+
+export default {
+  name: 'PublishFileBrowser',
+  components: { GirderFileManager },
+  computed: {
+    isDandiset() {
+      return !!(this.location && this.location.meta && this.location.meta.dandiset);
+    },
+    location: {
+      get() {
+        return this.$store.state.girder.browseLocation;
+      },
+      set(value) {
+        this.setBrowseLocation(value);
+      },
+    },
+    ...mapState('girder', ['selected']),
+    ...mapGetters('girder', ['loggedIn']),
+  },
+  watch: {
+    location(newValue) {
+      const { _modelType, _id } = this.$route.params;
+
+      if (newValue._modelType !== _modelType || newValue._id !== _id) {
+        this.$router.push({ name: 'file-browser', params: { _modelType: newValue._modelType, _id: newValue._id } });
+      }
+    },
+  },
+  created() {
+    const location = getLocationFromRoute(this.$route);
+    this.setBrowseLocation(location);
+    this.fetchFullLocation(location);
+  },
+  methods: {
+    async handleAction(action) {
+      if (action.name === 'Delete') {
+        await this.$refs.girderFileManager.refresh();
+        this.setSelected([]);
+      }
+    },
+    ...mapMutations('girder', ['setBrowseLocation', 'setSelected']),
+    ...mapActions('girder', ['fetchFullLocation']),
+  },
+};
+</script>
+<style>
+.girder-file-browser .secondary .row .spacer {
+  display: none;
+}
+</style>


### PR DESCRIPTION
Notable changes:
- This replaces the use of a Girder id in the URL, with the dandiset identifier.
- FileBrowser.vue is now split into two components, one for published dandisets and one for drafts.

Some open questions:

- Should we remove the `..` navigation? Breadcrumbs technically facilitates its functionality, but I personally still like having it. Not sure how others feel.
- Does the breadcrumb area look alright?
- Would it makes sense to have a version switcher at the top right of the browser? It may be useful to some people, however I'm not sure if it's a good idea to give the user that much control in this specific section of the site.