### PR TITLE
Fix dandiset navigation

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -7,10 +7,7 @@
       v-for="(item, i) in items"
       :key="item._id"
       selectable
-      :to="{
-        name: 'dandisetLanding',
-        params: { identifier: item.meta.dandiset.identifier, origin }
-      }"
+      :to="dandisetLink(item)"
     >
       <v-row
         no-gutters
@@ -73,7 +70,7 @@
 import moment from 'moment';
 import filesize from 'filesize';
 
-import { getDandisetContact } from '@/utils';
+import { getDandisetContact, draftVersion } from '@/utils';
 import { girderRest } from '@/rest';
 
 export default {
@@ -106,6 +103,16 @@ export default {
   methods: {
     filesize,
     getDandisetContact,
+    dandisetLink(dandiset) {
+      return {
+        name: 'dandisetLanding',
+        params: {
+          origin: this.origin,
+          identifier: dandiset.meta.dandiset.identifier,
+          version: draftVersion,
+        },
+      };
+    },
     formatDate(date) {
       return moment(date).format('LL');
     },

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -75,7 +75,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapMutations } from 'vuex';
 
 import SCHEMA from '@/assets/schema/dandiset.json';
 import NEW_SCHEMA from '@/assets/schema/dandiset_new.json';
@@ -174,9 +174,13 @@ export default {
   },
   methods: {
     navigateBack() {
+      this.setGirderDandiset(null);
+      this.setPublishDandiset(null);
+
       const route = this.$route.params.origin || { name: 'publicDandisets' };
       this.$router.push(route);
     },
+    ...mapMutations('dandiset', ['setGirderDandiset', 'setPublishDandiset']),
   },
 };
 </script>


### PR DESCRIPTION
Depends on #403.

Fixes a bug I found where clicking on a dandiset from the dandiset listing page would display the version of that dandiset that was previously selected (instead of starting with draft) due to `publishDandiset` not being set to `null` after leaving the DLP.