### PR TITLE
Remove flake8-blind-except

### DIFF
--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -19,7 +19,6 @@ skip_install = true
 deps =
     flake8
     flake8-black
-    flake8-blind-except
     flake8-bugbear
     flake8-docstrings
     flake8-import-order


### PR DESCRIPTION
[flake8-blind-except](https://github.com/elijahandrews/flake8-blind-except)'s sole functionality to generate flake8 errors about bare `except:` blocks — something that is already done by [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) (as B001) and flake8 itself (as [pycodestyle](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes)'s E722).