### PR TITLE
Test against multiple Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
-version: 2
+version: 2.1
 jobs:
   test-server:
+    parameters:
+      python_version:
+        type: string
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:<< parameters.python_version >>
       - image: circleci/mongo:4.2
         command: ["mongod", "--storageEngine", "ephemeralForTest", "--dbpath", "/data/db"]
     steps:
@@ -120,7 +123,10 @@ workflows:
   version: 2
   test_and_deploy:
     jobs:
-      - test-server
+      - test-server:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
       - test-gui
       - test-e2e:
           requires:


### PR DESCRIPTION
This PR adjusts the CircleCI configuration so that the job that runs `tox` will be run under each supported Python minor version rather than just under Python 3.6.  Python occasionally makes backwards-incompatible changes that make such multiversion tests necessary, like the deprecation & removal of ABCs from `collections`, or the proposed deprecations & removals in [PEP 594](https://www.python.org/dev/peps/pep-0594/).