### PR TITLE
Properly activate venv in test-e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,19 +49,23 @@ jobs:
       - checkout
       - run:
           name: Create a virtualenv for installation
-          command: |
-            python3 -m venv install_env
-            . install_env/bin/activate
+          command: python3 -m venv install_env
       - run:
           name: Upgrade pip
-          command: pip install -U pip
+          command: |
+            . install_env/bin/activate
+            pip install -U pip
       - run:
           name: Install girder-dandi-archive
-          command: pip install .
+          command: |
+            . ../install_env/bin/activate
+            pip install .
           working_directory: girder-dandi-archive
       - run:
           name: Run girder-dandi-archive in the background
-          command: girder serve
+          command: |
+            . ../install_env/bin/activate
+            girder serve
           working_directory: girder-dandi-archive
           background: true
       - run:
@@ -93,9 +97,7 @@ jobs:
       - checkout
       - run:
           name: Create a virtualenv for deployment
-          command: |
-            python3 -m venv deployment_env
-            . deployment_env/bin/activate
+          command: python3 -m venv deployment_env
       - run:
           name: Activate virtual environment
           command: echo ". $CIRCLE_WORKING_DIRECTORY/deployment_env/bin/activate" >> $BASH_ENV


### PR DESCRIPTION
The test-e2e job in the CircleCI configuration currently attempts to activate the `install_env` venv by running `. install_env/bin/activate` in the same step in which it is created.  Unfortunately, as steps are run in separate processes, this will not succeed in activating the venv in subsequent steps.  Instead, one needs to run the `activate` script at the start of each step in which the venv needs to be active.

The failure to activate the venv correctly is already causing problems, as you'll see if you run the CircleCI jobs today.  Today, July 19, the `dogpile.cache` project (a dependency of girder) released version 1.0.0, which (among other changes) introduced a dependency on `stevedore`, which in turn requires `importlib-metadata >=1.7.0` on pre-3.8 Pythons.  However, the Python images used by CircleCI come with poetry pre-installed, the latest version of which depends on `importlib-metadata >=1.1.3, <1.2.0`.  Installing `girder-dandi-archive` without using a venv leads to an environment with containing both `stevedore` but only version 1.1.3 of `importlib-metadata`, which leads to an error when `girder serve` is run (which ultimately imports `pkg_resources`, which can't handle version conflicts).  Properly using a venv avoids this issue.