### PR TITLE
Require ownership for lock endpoints

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -324,7 +324,7 @@ class DandiResource(Resource):
             "size": drafts["size"],
         }
 
-    @access.user(scope=TokenScope.DATA_OWN)
+    @access.user
     @autoDescribeRoute(
         Description("Lock a Dandiset").param("identifier", "Dandiset Identifier", paramType="path")
     )
@@ -332,7 +332,7 @@ class DandiResource(Resource):
     def lock_dandiset(self, identifier, params):
         locking.lock(identifier, self.getCurrentUser())
 
-    @access.user(scope=TokenScope.DATA_OWN)
+    @access.user
     @autoDescribeRoute(
         Description("Unlock a Dandiset").param(
             "identifier", "Dandiset Identifier", paramType="path"

--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -324,7 +324,7 @@ class DandiResource(Resource):
             "size": drafts["size"],
         }
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_OWN)
     @autoDescribeRoute(
         Description("Lock a Dandiset").param("identifier", "Dandiset Identifier", paramType="path")
     )
@@ -332,7 +332,7 @@ class DandiResource(Resource):
     def lock_dandiset(self, identifier, params):
         locking.lock(identifier, self.getCurrentUser())
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_OWN)
     @autoDescribeRoute(
         Description("Unlock a Dandiset").param(
             "identifier", "Dandiset Identifier", paramType="path"

--- a/web/src/components/AppBar/ApiKeyItem.vue
+++ b/web/src/components/AppBar/ApiKeyItem.vue
@@ -66,7 +66,7 @@ export default {
         ({ data } = await girderRest.post('api_key', null, {
           params: {
             name: 'dandicli',
-            scope: JSON.stringify(['core.data.read', 'core.data.write']),
+            scope: JSON.stringify(['core.data.read', 'core.data.write', 'core.data.own']),
             // days
             tokenDuration: 30,
             active: true,

--- a/web/src/components/AppBar/ApiKeyItem.vue
+++ b/web/src/components/AppBar/ApiKeyItem.vue
@@ -66,7 +66,7 @@ export default {
         ({ data } = await girderRest.post('api_key', null, {
           params: {
             name: 'dandicli',
-            scope: JSON.stringify(['core.data.read', 'core.data.write', 'core.data.own']),
+            scope: null,
             // days
             tokenDuration: 30,
             active: true,


### PR DESCRIPTION
The lock and unlock endpoints now require ownership of the dandiset.

IIRC we decided that the only permission level was ownership. Non-owners cannot modify the dandiset, so they should not be able to lock the dandiset.

Fetching the current lock owner is already public.

Fixes #422 