### PR TITLE
Handle trailing slash in publishRest baseURL

### DIFF
--- a/web/.env.development
+++ b/web/.env.development
@@ -1,2 +1,2 @@
 VUE_APP_API_ROOT=http://localhost:8080/api/v1
-VUE_APP_PUBLISH_API_ROOT=http://localhost:8000/api
+VUE_APP_PUBLISH_API_ROOT=http://localhost:8000/api/

--- a/web/src/rest.js
+++ b/web/src/rest.js
@@ -1,8 +1,15 @@
 import axios from 'axios';
 import { RestClient } from '@girder/components/src';
 
-const apiRoot = process.env.VUE_APP_API_ROOT;
-const publishApiRoot = process.env.VUE_APP_PUBLISH_API_ROOT;
+// Ensure doesn't contain trailing slash
+const apiRoot = process.env.VUE_APP_API_ROOT.endsWith('/')
+  ? process.env.VUE_APP_API_ROOT.slice(0, -1)
+  : process.env.VUE_APP_API_ROOT;
+
+// Ensure contains trailing slash
+const publishApiRoot = process.env.VUE_APP_PUBLISH_API_ROOT.endsWith('/')
+  ? process.env.VUE_APP_PUBLISH_API_ROOT
+  : `${process.env.VUE_APP_PUBLISH_API_ROOT}/`;
 
 function girderize(publishedDandiset) {
   const { // eslint-disable-next-line camelcase
@@ -24,8 +31,9 @@ const publishRest = axios.create({ baseURL: publishApiRoot });
 Object.assign(publishRest, {
   assetDownloadURI(asset) {
     const { uuid, version: { version, dandiset: { identifier } } } = asset;
-    const baseURL = publishRest.defaults.baseURL.endsWith('/') ? publishRest.defaults.baseURL.slice(0, -1) : publishRest.defaults.baseURL;
-    return `${baseURL}/dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;
+    const { baseURL } = publishRest.defaults;
+
+    return `${baseURL}dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;
   },
   async assets(identifier, version, config = {}) {
     try {

--- a/web/src/rest.js
+++ b/web/src/rest.js
@@ -1,4 +1,3 @@
-
 import axios from 'axios';
 import { RestClient } from '@girder/components/src';
 
@@ -25,7 +24,8 @@ const publishRest = axios.create({ baseURL: publishApiRoot });
 Object.assign(publishRest, {
   assetDownloadURI(asset) {
     const { uuid, version: { version, dandiset: { identifier } } } = asset;
-    return `${publishRest.defaults.baseURL}/dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;
+    const baseURL = publishRest.defaults.baseURL.endsWith('/') ? publishRest.defaults.baseURL.slice(0, -1) : publishRest.defaults.baseURL;
+    return `${baseURL}/dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;
   },
   async assets(identifier, version, config = {}) {
     try {


### PR DESCRIPTION
Fixes #419 

This was due to not handling trailing slashes in the `VUE_APP_PUBLISH_API_ROOT` environment variable, an oversight because of a difference between the local variables (in `.env.development`), and the ones being set on deploy. I've updated `.env.development` to match the format of the deploy environment.