### PR TITLE
Remove generic girder registration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,7 @@ jobs:
           working_directory: test
           environment:
             CLIENT_URL: http://localhost:8085
+            GIRDER_URL: http://localhost:8080
 
   provision:
     docker:

--- a/test/README.md
+++ b/test/README.md
@@ -14,10 +14,10 @@ Be aware of this when setting up CI or Docker images though.
 
 ## Running Tests
 You will need a running instance of the app, both the `web` and `girder` components.
-Assuming the web app is running at `http://localhost:8085`:
+Assuming the web app is running at `http://localhost:8085` and girder is running at `http://localhost:8080`:
 ```bash
 # within "test"
-CLIENT_URL=http://localhost:8085 yarn run test
+CLIENT_URL=http://localhost:8085 GIRDER_URL=http://localhost:8080 yarn run test
 ```
 
 ## Debugging Tests
@@ -26,7 +26,7 @@ For browser based tests, it is very helpful to be able to see the state of the b
 Use this command to run the browser in headful mode and extend the Jest test timeout to 1 hour:
 ```bash
 # within "test"
-CLIENT_URL=http://localhost:8085 yarn run test-debug
+CLIENT_URL=http://localhost:8085 GIRDER_URL=http://localhost:8080 yarn run test-debug
 ```
 You can also include `await jestPuppeteer.debug();` at any point in the test to create a manual breakpoint.
 

--- a/test/src/tests/account.test.js
+++ b/test/src/tests/account.test.js
@@ -5,29 +5,9 @@ import {
   vListItem,
   vIcon,
 } from 'jest-puppeteer-vuetify';
-import { uniqueId, registerNewUser } from '../util';
+import { registerNewUser } from '../util';
 
 describe('account management', () => {
-  it('registers a new user', async () => {
-    const username = `user${uniqueId()}`;
-    const email = `${username}@dandi.test`;
-    const password = 'password'; // Top secret
-
-    await expect(page).toClickXPath(vBtn('Create Account'));
-
-    await expect(page).toFillXPath(vTextField('Username'), username);
-    await expect(page).toFillXPath(vTextField('Email'), email);
-    await expect(page).toFillXPath(vTextField('First Name'), 'Mister');
-    await expect(page).toFillXPath(vTextField('Last Name'), 'Roboto');
-    await expect(page).toFillXPath(vTextField('Password'), password);
-    await expect(page).toFillXPath(vTextField('Retype password'), password);
-
-    await expect(page).toClickXPath(vBtn('Register'));
-
-    // the user avatar contains the initials and is only rendered when logged in successfully
-    await expect(page).toContainXPath(vAvatar('MR'));
-  });
-
   it('logs the user out', async () => {
     await registerNewUser();
 

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -13,28 +13,6 @@ export function uniqueId() {
 }
 
 /**
- * Register a new user with a random username.
- *
- * @returns {object} { username, email, password }
- */
-export async function registerNewUser() {
-  const username = `user${uniqueId()}`;
-  const email = `${username}@dandi.test`;
-  const password = 'password'; // Top secret
-
-  // there is no way to register a new user without using OAuth
-  // use the girder API to create the user instead
-  await page.evaluate(({ username, email, password, GIRDER_URL }) => {
-    const params = `login=${username}&email=${email}&firstName=Mister&lastName=Roboto&password=${password}&admin=false`;
-    return fetch(`${GIRDER_URL}/api/v1/user?${params}`, { method: 'POST' })
-  }, { username, email, password, GIRDER_URL });
-
-  await login(username, password);
-
-  return { username, email, password };
-}
-
-/**
  * Logs in.
  *
  * @param {string} username
@@ -50,6 +28,35 @@ export async function login(username, password) {
     expect(page).toClickXPath(vBtn(['Login', vIcon('mdi-login')])),
     page.waitForNavigation({ waitUntil: 'networkidle0' }),
   ]);
+}
+
+/**
+ * Register a new user with a random username.
+ *
+ * @returns {object} { username, email, password }
+ */
+export async function registerNewUser() {
+  const username = `user${uniqueId()}`;
+  const email = `${username}@dandi.test`;
+  const password = 'password'; // Top secret
+
+  // there is no way to register a new user without using OAuth
+  // use the girder API to create the user instead
+  await page.evaluate(({
+    username, email, password, GIRDER_URL, // eslint-disable-line no-shadow
+  }) => {
+    // fetch is only available in the browser
+    // this function is run in the page context, so fetch is available
+    const params = `login=${username}&email=${email}&firstName=Mister&lastName=Roboto&password=${password}&admin=false`;
+    // eslint-disable-next-line no-undef
+    return fetch(`${GIRDER_URL}/api/v1/user?${params}`, { method: 'POST' });
+  }, {
+    username, email, password, GIRDER_URL,
+  });
+
+  await login(username, password);
+
+  return { username, email, password };
 }
 
 /**

--- a/web/src/views/UserRegisterView/UserRegisterView.vue
+++ b/web/src/views/UserRegisterView/UserRegisterView.vue
@@ -1,18 +1,41 @@
 <template>
   <v-container v-page-title="'Sign Up'">
-    <GirderRegister :oauth-providers="oauthProviders" />
+    <h4>Register with Github</h4>
+    <v-btn
+      v-for="provider in oauthProviders"
+      :key="provider.id"
+      :dark="iconMap[provider.id].dark"
+      :color="iconMap[provider.id].color"
+      :href="provider.url"
+      class="ml-0 mr-3"
+    >
+      <v-icon left="left">
+        {{ $vuetify.icons.values[iconMap[provider.id].icon] }}
+      </v-icon>
+      {{ provider.name }}
+    </v-btn>
   </v-container>
 </template>
 
 <script>
-import GirderRegister from '@girder/components/src/components/Authentication/Register.vue';
 import { OauthTokenPrefix, OauthTokenSuffix } from '@girder/components/src/rest';
 import girderRest, { loggedIn } from '@/rest';
 
+// Copied from https://github.com/girder/girder_web_components Authentication/OAuth.vue
+const iconMap = {
+  github: { dark: true, icon: 'github' },
+  google: { dark: true, icon: 'google', color: '#3367d6' },
+  linkedin: { dark: true, icon: 'linkedin', color: '#283e4a' },
+  bitbucket: { dark: false, icon: 'bitbucket' },
+  box: { dark: true, icon: 'box_com', color: '#0071f7' },
+  globus: { dark: true, icon: 'globus', color: '#335a95' },
+};
 export default {
   name: 'UserRegisterView',
-  components: {
-    GirderRegister,
+  data() {
+    return {
+      iconMap,
+    };
   },
   computed: {
     loggedIn,


### PR DESCRIPTION
Remove the GWC registration component and only support Github OAuth
registration.

Fixes #307 

I ended up removing the reference to the Girder Web Component registration component. The GWC OAuth component was designed specifically to work with a registration component, so I just copied the relevant bits in here. This will actually make it easier to recycle the UI components when we migrate to django OAuth.