### PR TITLE
fix: add quotes to ensure redirect symbol does not cause issues

### DIFF
--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -105,7 +105,7 @@
                   in a Python 3.6+ environment using command:
                 </v-list-item>
                 <v-list-item>
-                  <kbd>pip install dandi>=0.6.0</kbd>
+                  <kbd>pip install "dandi>=0.6.0"</kbd>
                 </v-list-item>
               </v-list>
             </v-expansion-panel-content>


### PR DESCRIPTION
reported by @jwodder on slack:

> That "pip install" command in the dropdown should put dandi>=0.6.0 in quotes because > is a shell redirection operator.