### PR TITLE
Add feature toggles to web client

### DIFF
--- a/web/src/featureToggle.js
+++ b/web/src/featureToggle.js
@@ -1,0 +1,53 @@
+/* eslint no-console: 0 */
+/* eslint no-throw-literal: 0 */
+import Vue from 'vue';
+
+// Define all feature toggles here
+// They can also be enabled/disabled here for development
+const TOGGLES = {
+  UNIFIED_API: false,
+};
+
+// Create a component to hold the feature toggles reactively
+// This object can be mutated at runtime to enable/disable feature toggles
+const featureToggles = new Vue({
+  data() {
+    return TOGGLES;
+  },
+});
+
+// Generate the computed prop to use in the mixin
+const computed = Object.keys(TOGGLES).reduce((result, toggle) => {
+  // eslint-disable-next-line no-param-reassign
+  result[toggle] = () => featureToggles[toggle];
+  return result;
+}, {});
+
+// Register the feature toggles as computed properties on all components
+// Now feature toggles are available on all components and templates without any imports
+Vue.mixin({ computed });
+
+// We also want to support toggling feature toggles in branch previews and in master
+// These functions are made available globally so they can be called from the console
+
+/** Enables a feature toggle. Only usable from the console. */
+function enable(featureToggle) {
+  if (!(featureToggle in TOGGLES)) {
+    throw `Feature toggle ${featureToggle} is not defined`;
+  }
+  featureToggles[featureToggle] = true;
+  console.log(`Feature toggle '${featureToggle}' enabled`);
+}
+
+/** Disables a feature toggle. Only usable from the console. */
+function disable(featureToggle) {
+  if (!(featureToggle in TOGGLES)) {
+    throw `Feature toggle ${featureToggle} is not defined`;
+  }
+  featureToggles[featureToggle] = false;
+  console.log(`Feature toggle '${featureToggle}' disabled`);
+}
+
+// Register enable and disable on the window object so they are accessible from the console
+window.enable = enable;
+window.disable = disable;

--- a/web/src/featureToggle.js
+++ b/web/src/featureToggle.js
@@ -2,37 +2,34 @@
 /* eslint no-throw-literal: 0 */
 import Vue from 'vue';
 
-// Define all feature toggles here
-// They can also be enabled/disabled here for development
-const TOGGLES = {
-  UNIFIED_API: false,
-};
-
 // Create a component to hold the feature toggles reactively
 // This object can be mutated at runtime to enable/disable feature toggles
 const featureToggles = new Vue({
   data() {
-    return TOGGLES;
+    return {
+      UNIFIED_API: false,
+    };
   },
 });
 
-// Generate the computed prop to use in the mixin
-const computed = Object.keys(TOGGLES).reduce((result, toggle) => {
-  // eslint-disable-next-line no-param-reassign
-  result[toggle] = () => featureToggles[toggle];
-  return result;
-}, {});
-
 // Register the feature toggles as computed properties on all components
 // Now feature toggles are available on all components and templates without any imports
-Vue.mixin({ computed });
+Vue.mixin({
+  computed: {
+    UNIFIED_API() {
+      return featureToggles.UNIFIED_API;
+    },
+  },
+});
+
+export default featureToggles;
 
 // We also want to support toggling feature toggles in branch previews and in master
 // These functions are made available globally so they can be called from the console
 
 /** Enables a feature toggle. Only usable from the console. */
 function enable(featureToggle) {
-  if (!(featureToggle in TOGGLES)) {
+  if (!(featureToggle in featureToggles)) {
     throw `Feature toggle ${featureToggle} is not defined`;
   }
   featureToggles[featureToggle] = true;
@@ -41,7 +38,7 @@ function enable(featureToggle) {
 
 /** Disables a feature toggle. Only usable from the console. */
 function disable(featureToggle) {
-  if (!(featureToggle in TOGGLES)) {
+  if (!(featureToggle in featureToggles)) {
     throw `Feature toggle ${featureToggle} is not defined`;
   }
   featureToggles[featureToggle] = false;

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
 
 import App from '@/App.vue';
+import '@/featureToggle';
 import router from '@/router';
 import store from '@/store';
 import { girderRest } from '@/rest';

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -27,8 +27,8 @@
               Help
               <v-icon
                 color="primary"
-                v-on="on"
                 small
+                v-on="on"
               >
                 mdi-help-circle
               </v-icon>


### PR DESCRIPTION
 * Add a new feature toggle, `UNIFIED_API`, which defaults to `false`.
 * A constant is now exposed on every component for every defined
feature toggle. Components can access the new toggle with
`if (this.UNIFIED_API) {...}` or in templates with `v-if="UNIFIED_API"`.
 * Add two functions to the global scope, `enable` and `disable`.
Typing `enable('UNIFIED_API')` into the web console will enable the
feature toggle for the rest of the session, while
`disable('UNIFIED_API')` will disable it.
 * Toggles are listed in `web/src/featureToggle.js`. For development,
they can be temporarily enabled/disabled there.

Also, a minor linting change was applied to `DownloadDialog`.

You can see this in action on the netlify preview. Just open the web console and type `enable('UNIFIED_API')` and a console log should report the successful toggling.