### PR TITLE
Get version "description" from metadata

### DIFF
--- a/web/src/rest.js
+++ b/web/src/rest.js
@@ -13,14 +13,13 @@ const publishApiRoot = process.env.VUE_APP_PUBLISH_API_ROOT.endsWith('/')
 
 function girderize(publishedDandiset) {
   const { // eslint-disable-next-line camelcase
-    created, modified, dandi_id, version, metadata, name, description,
+    created, modified, dandi_id, version, metadata, name,
   } = publishedDandiset;
   return {
     created,
     updated: modified,
     version,
     name,
-    description,
     lowerName: dandi_id,
     meta: metadata,
   };

--- a/web/src/rest.js
+++ b/web/src/rest.js
@@ -21,7 +21,9 @@ function girderize(publishedDandiset) {
     version,
     name,
     lowerName: dandi_id,
-    meta: metadata,
+    meta: {
+      dandiset: metadata,
+    },
   };
 }
 

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -137,7 +137,6 @@ export default {
       if (this.publishDandiset) {
         return {
           name: this.publishDandiset.name,
-          description: this.publishDandiset.description,
           ...this.publishDandiset.meta.dandiset,
         };
       }


### PR DESCRIPTION
For now, the "description" and other metadata fields on a publish version will live opaquely inside unvalidated "metadata".

"name" will continue to live at the top level and be validated, as it is an essential sanity check.