### PR TITLE
Change django publish URL

### DIFF
--- a/girder-dandi-archive/girder_dandi_archive/rest.py
+++ b/girder-dandi-archive/girder_dandi_archive/rest.py
@@ -248,7 +248,7 @@ class DandiResource(Resource):
         # Publish the new version
         try:
             response = requests.post(
-                urljoin(publish_api_url, f"dandisets/{identifier}/versions/publish/"),
+                urljoin(publish_api_url, f"dandisets/{identifier}/draft/publish/"),
                 headers={"Authorization": f"Token {publish_api_key}"},
             )
             response.raise_for_status()


### PR DESCRIPTION
This is dependent on https://github.com/dandi/dandi-publish/pull/151