### PR TITLE
Rename UNIFIED_API to DJANGO_API

### DIFF
--- a/web/src/components/AppBar/UserMenu.vue
+++ b/web/src/components/AppBar/UserMenu.vue
@@ -64,7 +64,7 @@ export default {
   },
   methods: {
     async logout() {
-      if (toggles.UNIFIED_API) {
+      if (toggles.DJANGO_API) {
         await publishRest.logout();
       } else {
         await girderRest.logout();

--- a/web/src/featureToggle.js
+++ b/web/src/featureToggle.js
@@ -7,7 +7,7 @@ import Vue from 'vue';
 const featureToggles = new Vue({
   data() {
     return {
-      UNIFIED_API: false,
+      DJANGO_API: false,
     };
   },
 });
@@ -16,8 +16,8 @@ const featureToggles = new Vue({
 // Now feature toggles are available on all components and templates without any imports
 Vue.mixin({
   computed: {
-    UNIFIED_API() {
-      return featureToggles.UNIFIED_API;
+    DJANGO_API() {
+      return featureToggles.DJANGO_API;
     },
   },
 });

--- a/web/src/rest/index.js
+++ b/web/src/rest/index.js
@@ -2,7 +2,7 @@ import girderRest from '@/rest/girder';
 import publishRest from '@/rest/publish';
 import toggles from '@/featureToggle';
 
-const user = () => ((toggles.UNIFIED_API) ? publishRest.user : girderRest.user);
+const user = () => ((toggles.DJANGO_API) ? publishRest.user : girderRest.user);
 const loggedIn = () => !!user();
 
 export {

--- a/web/src/rest/publish.js
+++ b/web/src/rest/publish.js
@@ -128,11 +128,11 @@ export default publishRest;
 
 // This is a hack to allow username/password logins to django
 window.setTokenHack = (token) => {
-  if (toggles.UNIFIED_API) {
+  if (toggles.DJANGO_API) {
     publishRest.token = token;
     publishRest.user = {};
     console.log(`Token set to ${token}`);
   } else {
-    console.log('UNIFIED_API is not enabled');
+    console.log('DJANGO_API is not enabled');
   }
 };

--- a/web/src/views/UserLoginView/UserLoginView.vue
+++ b/web/src/views/UserLoginView/UserLoginView.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container v-page-title="'Log In'">
     <GirderAuth
-      v-if="!UNIFIED_API"
+      v-if="!DJANGO_API"
       :force-otp="false"
       :show-forgot-password="false"
       :oauth="true"


### PR DESCRIPTION
Unification is no longer the objective, but the toggle still hides useful functionality and more functionality needs to be added, so renaming it is the easiest course of action.