### PR TITLE
Django list dandisets

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -23,7 +23,7 @@
             </v-list-item-title>
             <v-list-item-subtitle>
               <v-chip
-                v-if="item.version"
+                v-if="item.version && item.version !== 'draft'"
                 small
                 color="light-blue lighten-4"
                 text-color="light-blue darken-3"
@@ -74,6 +74,7 @@ import moment from 'moment';
 import filesize from 'filesize';
 
 import { getDandisetContact } from '@/utils';
+import toggles from '@/featureToggle';
 import { girderRest } from '@/rest';
 
 export default {
@@ -95,6 +96,9 @@ export default {
   },
   asyncComputed: {
     async dandisetStats() {
+      if (toggles.DJANGO_API) {
+        return this.dandisets;
+      }
       const { items } = this;
       return Promise.all(items.map(async (item) => {
         const { identifier } = item.meta.dandiset;

--- a/web/src/rest/publish.js
+++ b/web/src/rest/publish.js
@@ -9,16 +9,22 @@ const publishApiRoot = process.env.VUE_APP_PUBLISH_API_ROOT.endsWith('/')
 
 function girderize(publishedDandiset) {
   const { // eslint-disable-next-line camelcase
-    created, modified, dandi_id, version, metadata, name,
+    created, modified, dandiset, version, metadata, name, size, asset_count,
   } = publishedDandiset;
   return {
     created,
     updated: modified,
     version,
     name,
-    lowerName: dandi_id,
+    lowerName: name,
+    bytes: size,
+    items: asset_count,
     meta: {
-      dandiset: metadata,
+      dandiset: {
+        ...metadata,
+        name,
+        identifier: dandiset.identifier,
+      },
     },
   };
 }


### PR DESCRIPTION
To test:
* Open [netlify preview](https://deploy-preview-514--gui-dandiarchive-org.netlify.app/)
* Pull up the console and run `enable('DJANGO_API');`
* Visit the public dandisets page (navigate away and back again if you are already there). When it loads it should pull data from api.dandiarchive.org instead of girder.dandiarchive.org.