### PR TITLE
Render Django data on the Dandiset page

### DIFF
--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -74,7 +74,7 @@ ignore =
     D10,
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="term"
+addopts = --verbose --strict-markers --showlocals --cov-report="term"
 testpaths = tests
 filterwarnings =
     error

--- a/web/src/store/dandiset.js
+++ b/web/src/store/dandiset.js
@@ -38,7 +38,7 @@ export default {
       commit('setOwners', null);
       state.loading = false;
     },
-    async initializeDandisets({ state, dispatch }, { identifier, version }) {
+    async initializeDandisets({ dispatch }, { identifier, version }) {
       await dispatch('uninitializeDandisets');
 
       if (toggles.DJANGO_API) {
@@ -65,12 +65,10 @@ export default {
     async fetchPublishDandiset({ state, commit }, { identifier, version }) {
       state.loading = true;
 
-      if (!version) {
-        version = (await publishRest.mostRecentVersion(identifier)).version;
-      }
+      const sanitizedVersion = version || (await publishRest.mostRecentVersion(identifier)).version;
 
       try {
-        const data = await publishRest.specificVersion(identifier, version);
+        const data = await publishRest.specificVersion(identifier, sanitizedVersion);
         commit('setPublishDandiset', data);
       } catch (err) {
         commit('setPublishDandiset', null);

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -63,10 +63,6 @@ function getDandisetContact(dandiset) {
 }
 
 const draftVersion = 'draft';
-const dandisetHasVersion = (versions, version) => {
-  const versionNumbers = versions.map((v) => v.version);
-  return versionNumbers.includes(version);
-};
 
 export {
   dandiUrl,
@@ -79,5 +75,4 @@ export {
   copyToClipboard,
   getDandisetContact,
   draftVersion,
-  dandisetHasVersion,
 };

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -276,9 +276,8 @@ export default {
     currentDandiset() {
       if (toggles.DJANGO_API) {
         return this.publishDandiset;
-      } else {
-        return this.girderDandiset;
       }
+      return this.girderDandiset;
     },
     draftDandiset() {
       return this.currentVersion === draftVersion;
@@ -305,10 +304,9 @@ export default {
     versions() {
       if (toggles.DJANGO_API) {
         return this.publishedVersions || [];
-      } else {
-        // Girder only has the draft version
-        return [{ version: draftVersion }];
       }
+      // Girder only has the draft version
+      return [{ version: draftVersion }];
     },
     ...mapState('dandiset', {
       girderDandiset: (state) => state.girderDandiset,
@@ -325,11 +323,10 @@ export default {
       if (toggles.DJANGO_API) {
         const { items, folders, bytes } = this.currentDandiset;
         return { items, folders, bytes };
-      } else {
-        const { identifier } = this.currentDandiset.meta.dandiset;
-        const { data } = await girderRest.get(`/dandi/${identifier}/stats`);
-        return data;
       }
+      const { identifier } = this.currentDandiset.meta.dandiset;
+      const { data } = await girderRest.get(`/dandi/${identifier}/stats`);
+      return data;
     },
   },
   watch: {

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -321,8 +321,8 @@ export default {
   asyncComputed: {
     async stats() {
       if (toggles.DJANGO_API) {
-        const { items, folders, bytes } = this.currentDandiset;
-        return { items, folders, bytes };
+        const { items, bytes } = this.currentDandiset;
+        return { items, bytes };
       }
       const { identifier } = this.currentDandiset.meta.dandiset;
       const { data } = await girderRest.get(`/dandi/${identifier}/stats`);

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -50,6 +50,7 @@
             {{ stats.items }}
           </v-col>
           <v-col
+            v-if="!DJANGO_API"
             class="text--secondary mx-2 pa-0 py-1"
             cols="auto"
           >
@@ -230,6 +231,7 @@ import { loggedIn, user, girderRest } from '@/rest';
 import moment from 'moment';
 import filesize from 'filesize';
 
+import toggles from '@/featureToggle';
 import { draftVersion } from '@/utils';
 import DandisetOwnersDialog from './DandisetOwnersDialog.vue';
 
@@ -272,9 +274,11 @@ export default {
       return null;
     },
     currentDandiset() {
-      // Done this way because we'll want to add in
-      // fetching stats from the publish endpoint later on.
-      return this.girderDandiset;
+      if (toggles.DJANGO_API) {
+        return this.publishDandiset;
+      } else {
+        return this.girderDandiset;
+      }
     },
     draftDandiset() {
       return this.currentVersion === draftVersion;
@@ -299,10 +303,12 @@ export default {
       return filesize(stats.bytes);
     },
     versions() {
-      // const versions = this.publishedVersions || [];
-      // TODO: properly render all versions
-      const versions = [];
-      return [{ version: draftVersion }, ...versions];
+      if (toggles.DJANGO_API) {
+        return this.publishedVersions || [];
+      } else {
+        // Girder only has the draft version
+        return [{ version: draftVersion }];
+      }
     },
     ...mapState('dandiset', {
       girderDandiset: (state) => state.girderDandiset,
@@ -316,9 +322,14 @@ export default {
   },
   asyncComputed: {
     async stats() {
-      const { identifier } = this.currentDandiset.meta.dandiset;
-      const { data } = await girderRest.get(`/dandi/${identifier}/stats`);
-      return data;
+      if (toggles.DJANGO_API) {
+        const { items, folders, bytes } = this.currentDandiset;
+        return { items, folders, bytes };
+      } else {
+        const { identifier } = this.currentDandiset.meta.dandiset;
+        const { data } = await girderRest.get(`/dandi/${identifier}/stats`);
+        return data;
+      }
     },
   },
   watch: {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -21,7 +21,7 @@
           Dandiset Dashboard
         </v-toolbar-title>
         <v-progress-circular
-          v-if="!girderDandiset || loading"
+          v-if="!currentDandiset || loading"
           indeterminate
           class="ml-3"
         />

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -83,11 +83,10 @@ import NWB_SCHEMA from '@/assets/schema/dandiset_metanwb.json';
 
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import { draftVersion } from '@/utils';
+import toggles from '@/featureToggle';
 import MetaEditor from './MetaEditor.vue';
 import DandisetMain from './DandisetMain.vue';
 import DandisetDetails from './DandisetDetails.vue';
-import { publishRest } from '@/rest';
-import toggles from '@/featureToggle';
 
 export default {
   name: 'DandisetLandingView',
@@ -137,9 +136,8 @@ export default {
     currentDandiset() {
       if (toggles.DJANGO_API) {
         return this.publishDandiset;
-      } else {
-        return this.girderDandiset;
       }
+      return this.girderDandiset;
     },
     meta() {
       if (this.publishDandiset) {
@@ -188,12 +186,13 @@ export default {
         }
       } else {
         // With girder there is only two permissible versions, null and 'draft'
+        // eslint-disable-next-line no-lonely-if
         if (version) {
-          version = draftVersion;
+          this.navigateToVersion(draftVersion);
+        } else {
+          this.navigateToVersion(version);
         }
-        this.navigateToVersion(version);
       }
-
     },
   },
   methods: {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -42,7 +42,7 @@
         </v-btn>
       </v-toolbar>
       <v-container
-        v-if="girderDandiset"
+        v-if="currentDandiset"
         fluid
         class="grey lighten-4"
       >
@@ -82,10 +82,12 @@ import NEW_SCHEMA from '@/assets/schema/dandiset_new.json';
 import NWB_SCHEMA from '@/assets/schema/dandiset_metanwb.json';
 
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
-import { draftVersion, dandisetHasVersion } from '@/utils';
+import { draftVersion } from '@/utils';
 import MetaEditor from './MetaEditor.vue';
 import DandisetMain from './DandisetMain.vue';
 import DandisetDetails from './DandisetDetails.vue';
+import { publishRest } from '@/rest';
+import toggles from '@/featureToggle';
 
 export default {
   name: 'DandisetLandingView',
@@ -132,6 +134,13 @@ export default {
 
       return { properties, required };
     },
+    currentDandiset() {
+      if (toggles.DJANGO_API) {
+        return this.publishDandiset;
+      } else {
+        return this.girderDandiset;
+      }
+    },
     meta() {
       if (this.publishDandiset) {
         return {
@@ -163,40 +172,31 @@ export default {
       async handler(identifier) {
         const { version } = this;
         await this.$store.dispatch('dandiset/initializeDandisets', { identifier, version });
-        if (!this.publishDandiset) { this.navigateToDefaultDandiset(); }
+        // TODO: check for invalid versions here
       },
     },
     async version(version) {
       // On version change, fetch the new dandiset (not initial)
-
-      const { identifier } = this;
-      if (version === draftVersion) {
-        this.$store.commit('dandiset/setPublishDandiset', null);
-      } else {
+      if (toggles.DJANGO_API) {
+        const { identifier } = this;
         await this.$store.dispatch('dandiset/fetchPublishDandiset', { identifier, version });
-
         // If the above await call didn't result in publishDandiset being set, navigate to a default
-        if (!this.publishDandiset) { this.navigateToDefaultDandiset(); }
+        if (!this.publishDandiset) {
+          // Omitting version will fetch the most recent version instead
+          await this.$store.dispatch('dandiset/fetchPublishDandiset', { identifier });
+          this.navigateToVersion(this.publishDandiset.version);
+        }
+      } else {
+        // With girder there is only two permissible versions, null and 'draft'
+        if (version) {
+          version = draftVersion;
+        }
+        this.navigateToVersion(version);
       }
+
     },
   },
   methods: {
-    navigateToDefaultDandiset() {
-      // Set default version to most recent if this dandiset has versions
-      // Otherwise set it to draft
-      let version = draftVersion;
-      const { dandisetVersions: versions } = this;
-
-      if (versions && versions.length) {
-        if (dandisetHasVersion(versions, this.version)) { return; }
-        if (this.version !== draftVersion) {
-          // The version isn't 'draft', and isn't one of the known versions,
-          // thus it's not valid, so redirect to latest version
-          version = versions[0].version;
-        }
-      }
-      this.navigateToVersion(version);
-    },
     navigateToVersion(version) {
       if (this.$route.params.version === version) return;
 

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -148,6 +148,7 @@ import { mapState, mapGetters } from 'vuex';
 
 import { dandiUrl } from '@/utils';
 import { girderRest, loggedIn, user } from '@/rest';
+import toggles from '@/featureToggle';
 
 import CopyText from '@/components/CopyText.vue';
 import DownloadDialog from './DownloadDialog.vue';
@@ -205,10 +206,17 @@ export default {
       return null;
     },
     fileBrowserLink() {
-      const { version } = this;
-      const { identifier } = this.girderDandiset.meta.dandiset;
+      if (toggles.DJANGO_API) {
+        const { version } = this;
+        const { identifier } = this.publishDandiset.meta.dandiset;
+        // TODO: this probably does not work correctly yet
+        return { name: 'fileBrowser', params: { identifier, version } };
+      } else {
+        const { version } = this;
+        const { identifier } = this.girderDandiset.meta.dandiset;
 
-      return { name: 'fileBrowser', params: { identifier, version } };
+        return { name: 'fileBrowser', params: { identifier, version } };
+      }
     },
     permalink() {
       return `${dandiUrl}/dandiset/${this.meta.identifier}/${this.version}`;
@@ -229,6 +237,9 @@ export default {
   asyncComputed: {
     lockOwner: {
       async get() {
+        if (toggles.DJANGO_API) {
+          return null;
+        }
         const { data: owner } = await girderRest.get(`/dandi/${this.girderDandiset.meta.dandiset.identifier}/lock/owner`);
         if (!owner) {
           return null;

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -211,12 +211,11 @@ export default {
         const { identifier } = this.publishDandiset.meta.dandiset;
         // TODO: this probably does not work correctly yet
         return { name: 'fileBrowser', params: { identifier, version } };
-      } else {
-        const { version } = this;
-        const { identifier } = this.girderDandiset.meta.dandiset;
-
-        return { name: 'fileBrowser', params: { identifier, version } };
       }
+      const { version } = this;
+      const { identifier } = this.girderDandiset.meta.dandiset;
+
+      return { name: 'fileBrowser', params: { identifier, version } };
     },
     permalink() {
       return `${dandiUrl}/dandiset/${this.meta.identifier}/${this.version}`;

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -169,9 +169,8 @@ export default {
     identifier() {
       if (toggles.DJANGO_API) {
         return this.publishDandiset.identifier;
-      } else {
-        return this.girderDandiset.meta.dandiset.identifier;
       }
+      return this.girderDandiset.meta.dandiset.identifier;
     },
     ...mapState('dandiset', {
       girderDandiset: (state) => state.girderDandiset,

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -118,6 +118,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
 import CopyText from '@/components/CopyText.vue';
+import toggles from '@/featureToggle';
 
 function formatDownloadCommand(identifier, version) {
   if (version === 'draft') {
@@ -165,8 +166,16 @@ export default {
       return (this.publishedVersions || [])
         .map((version, index) => ({ version: version.version, index }));
     },
+    identifier() {
+      if (toggles.DJANGO_API) {
+        return this.publishDandiset.identifier;
+      } else {
+        return this.girderDandiset.meta.dandiset.identifier;
+      }
+    },
     ...mapState('dandiset', {
-      identifier: (state) => state.girderDandiset.meta.dandiset.identifier,
+      girderDandiset: (state) => state.girderDandiset,
+      publishDandiset: (state) => state.publishDandiset,
       publishedVersions: (state) => state.versions,
     }),
     ...mapGetters('dandiset', {


### PR DESCRIPTION
To test:
* Open [netlify preview](https://deploy-preview-516--gui-dandiarchive-org.netlify.app/#/)
* Pull up the console and run `enable('DJANGO_API')`;
* Visit the public dandisets page. It should render a list of Django dandisets.
* Click on any dandiset.

The dandiset page should correctly render created/modified dates, file count/size, and all published versions.