### PR TITLE
Comment out girder nginx role

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -9,10 +9,10 @@
       vars:
         mongodb_data_path: /var/lib/mongodb
     - role: girder.girder
-    - role: girder.nginx
-      vars:
-        nginx_hostname: "girder.dandiarchive.org"
-        nginx_registration_email: "michael.grauer@kitware.com"
+#    - role: girder.nginx
+#      vars:
+#        nginx_hostname: "girder.dandiarchive.org"
+#        nginx_registration_email: "michael.grauer@kitware.com"
 
   tasks:
     - name: Install awscli


### PR DESCRIPTION
To work around a bug in Girder, we have manually set the client_max_body_size
on nginx to 400M. By commenting out the girder nginx role from ansible, we
prevent nginx from reprovisioning when ansible is run, as reprovisioning nginx
would overwrite the new setting of 400M.

A part of the workaround for #517