### PR TITLE
Django manage ownership

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -183,7 +183,7 @@ export default {
       if (!toggles.DJANGO_API) {
         return null;
       }
-      return publishRest.dandisets({ page: this.page, page_size: DANDISETS_PER_PAGE });
+      return publishRest.dandisets({ page: this.page, page_size: DANDISETS_PER_PAGE, user: this.user ? 'me' : null });
     },
     async mostRecentDandisetVersions() {
       if (this.djangoDandisetRequest === null) {

--- a/web/src/rest/publish.js
+++ b/web/src/rest/publish.js
@@ -107,6 +107,9 @@ const publishRest = new Vue({
     async dandisets(params) {
       return client.get('dandisets/', { params });
     },
+    async owners(identifier) {
+      return client.get(`dandisets/${identifier}/users/`);
+    },
     assetDownloadURI(asset) {
       const { uuid, version: { version, dandiset: { identifier } } } = asset;
       return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;

--- a/web/src/rest/publish.js
+++ b/web/src/rest/publish.js
@@ -110,6 +110,9 @@ const publishRest = new Vue({
     async owners(identifier) {
       return client.get(`dandisets/${identifier}/users/`);
     },
+    async setOwners(identifier, owners) {
+      return client.put(`dandisets/${identifier}/users/`, owners);
+    },
     async searchUsers(username) {
       const { data } = await client.get('users/search/?', { params: { username } });
       return data;

--- a/web/src/rest/publish.js
+++ b/web/src/rest/publish.js
@@ -110,6 +110,10 @@ const publishRest = new Vue({
     async owners(identifier) {
       return client.get(`dandisets/${identifier}/users/`);
     },
+    async searchUsers(username) {
+      const { data } = await client.get('users/search/?', { params: { username } });
+      return data;
+    },
     assetDownloadURI(asset) {
       const { uuid, version: { version, dandiset: { identifier } } } = asset;
       return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;

--- a/web/src/store/dandiset.js
+++ b/web/src/store/dandiset.js
@@ -47,8 +47,8 @@ export default {
         await dispatch('fetchPublishDandiset', { identifier, version });
       } else {
         await dispatch('fetchGirderDandiset', { identifier });
-        await dispatch('fetchOwners', identifier);
       }
+      await dispatch('fetchOwners', identifier);
     },
     async fetchDandisetVersions({ state, commit }, { identifier }) {
       state.loading = true;
@@ -87,8 +87,13 @@ export default {
     async fetchOwners({ state, commit }, identifier) {
       state.loading = true;
 
-      const { data } = await girderRest.get(`/dandi/${identifier}/owners`);
-      commit('setOwners', data);
+      if (toggles.DJANGO_API) {
+        const { data } = await publishRest.owners(identifier);
+        commit('setOwners', data);
+      } else {
+        const { data } = await girderRest.get(`/dandi/${identifier}/owners`);
+        commit('setOwners', data);
+      }
 
       state.loading = false;
     },

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -173,12 +173,12 @@
         <v-col cols="12">
           <v-chip
             v-for="owner in limitedOwners"
-            :key="owner.id"
+            :key="owner.id /* TODO remove this */ || owner.username"
             color="light-blue lighten-4"
             text-color="light-blue darken-3"
             class="font-weight-medium ma-1"
           >
-            {{ owner.login }}
+            {{ owner.login /* TODO remove this */ || owner.username }}
           </v-chip>
           <span
             v-if="numExtraOwners"

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -39,7 +39,7 @@
           <template v-for="(owner, i) in newOwners">
             <v-list-item :key="owner._id || owner.id">
               <v-list-item-title>
-                {{ owner.name }} ({{ owner.login }})
+                {{ owner.result }}
               </v-list-item-title>
               <v-list-item-action>
                 <v-btn
@@ -97,10 +97,10 @@ const girderize = (users) => users.map(({ username, first_name, last_name }) => 
   login: username,
   username,
   // eslint-disable-next-line camelcase
-  name: `${first_name} ${last_name}`,
+  name: (first_name && last_name) ? `${first_name} ${last_name}` : null,
 }));
 
-const addResult = (users) => users.map((u) => ({ ...u, result: `${u.name} (${u.login})` }));
+const addResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.login})` : u.login }));
 
 export default {
   name: 'DandisetOwnersDialog',
@@ -115,7 +115,7 @@ export default {
       search: null,
       loadingUsers: false,
       selection: null,
-      newOwners: addResult(this.owners),
+      newOwners: addResult((toggles.DJANGO_API) ? girderize(this.owners) : this.owners),
       items: [],
       throttledUpdate: _.debounce(this.updateItems, 200),
     };

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -100,7 +100,8 @@ const girderize = (users) => users.map(
   }),
 );
 
-const addResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.login})` : u.login }));
+// Includes a field `result` on each user which is the value displayed in the UI
+const appendResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.login})` : u.login }));
 
 export default {
   name: 'DandisetOwnersDialog',
@@ -115,7 +116,7 @@ export default {
       search: null,
       loadingUsers: false,
       selection: null,
-      newOwners: addResult((toggles.DJANGO_API) ? girderize(this.owners) : this.owners),
+      newOwners: appendResult((toggles.DJANGO_API) ? girderize(this.owners) : this.owners),
       items: [],
       throttledUpdate: _.debounce(this.updateItems, 200),
     };
@@ -137,7 +138,7 @@ export default {
       this.loadingUsers = true;
       if (toggles.DJANGO_API) {
         const users = await publishRest.searchUsers(this.search);
-        this.items = addResult(girderize(users));
+        this.items = appendResult(girderize(users));
       } else {
         const { data: { user: users } } = await girderRest.get('/resource/search', {
           params: {
@@ -149,7 +150,7 @@ export default {
         });
 
         // Needed to match existing owner document schema
-        this.items = addResult(userFormatConversion(users));
+        this.items = appendResult(userFormatConversion(users));
       }
 
       this.loadingUsers = false;

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -91,14 +91,14 @@ const userFormatConversion = (users) => users.map(({
   id: _id, level: _accessLevel, login, name: `${firstName} ${lastName}`,
 }));
 
-// eslint-disable-next-line camelcase
-const girderize = (users) => users.map(({ username, first_name, last_name }) => ({
-  id: username,
-  login: username,
-  username,
-  // eslint-disable-next-line camelcase
-  name: (first_name && last_name) ? `${first_name} ${last_name}` : null,
-}));
+const girderize = (users) => users.map(
+  ({ username, first_name: firstName, last_name: lastName }) => ({
+    id: username,
+    login: username,
+    username,
+    name: (firstName && lastName) ? `${firstName} ${lastName}` : null,
+  }),
+);
 
 const addResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.login})` : u.login }));
 


### PR DESCRIPTION
Fix the ownership chips and the Manage Ownership dialog when the DJANGO_API toggle is on.
To test:

- Open netlify preview
- Pull up the console and run enable('DJANGO_API');
- Visit the public dandisets page. It should render a list of Django dandisets.
- Click on a dandiset you own (according to Django).
- You should see the owners in the little blue chips.
- Run this in the console:
```
setTokenHack('put-your-django-API-key-here')
```
You can grab your current API key by hitting GET /auth/token/ on the swagger page.
- Click `Manage` and verify that the Manage Ownership dialog works as intended.

There is some slightly funky behavior where the initial list of owners in the Manage Ownership dialog does not include first/last names. Since it doesn't impact functionality significantly, I think it's fine to save that for later reengineering.

I added everyone I could think of to https://deploy-preview-524--gui-dandiarchive-org.netlify.app/#/dandiset/000001 so you should be able to test the dialog from there.