### PR TITLE
Fix deprecated pytest flag

### DIFF
--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -74,7 +74,7 @@ ignore =
     D10,
 
 [pytest]
-addopts = --verbose --strict --showlocals --cov-report="term"
+addopts = --verbose --strict-marks --showlocals --cov-report="term"
 testpaths = tests
 filterwarnings =
     error

--- a/girder-dandi-archive/tox.ini
+++ b/girder-dandi-archive/tox.ini
@@ -74,7 +74,7 @@ ignore =
     D10,
 
 [pytest]
-addopts = --verbose --strict-marks --showlocals --cov-report="term"
+addopts = --verbose --strict-markers --showlocals --cov-report="term"
 testpaths = tests
 filterwarnings =
     error


### PR DESCRIPTION
This flag was deprecated and is breaking builds.