### PR TITLE
Fix girder requests when DJANGO_API is on

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -114,15 +114,14 @@ export default defineComponent({
 
       if (toggles.DJANGO_API) {
         dandisetStats.value = dandisets as DandisetStats[];
+      } else {
+        const res = await Promise.all(dandisets.map(async (dandiset: any) => {
+          const { identifier } = dandiset.meta.dandiset;
+          const { data } = await girderRest.get(`/dandi/${identifier}/stats`);
+          return data;
+        }));
+        dandisetStats.value = res;
       }
-
-      const res = await Promise.all(dandisets.map(async (dandiset: any) => {
-        const { identifier } = dandiset.meta.dandiset;
-        const { data } = await girderRest.get(`/dandi/${identifier}/stats`);
-        return data;
-      }));
-
-      dandisetStats.value = res;
     }
 
     // Fetching dandiset stats must be done this way since we don't have access to asyncComputed


### PR DESCRIPTION
When the DJANGO_API is on there are still failing requests being made to
the girder server when browsing dandiset list pages. Those requests are
now wrapped in an else.