### PR TITLE
Convert featureToggles to TS

### DIFF
--- a/vetur.config.js
+++ b/vetur.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  projects: [
+    './web',
+  ],
+}

--- a/web/src/featureToggle.ts
+++ b/web/src/featureToggle.ts
@@ -28,23 +28,27 @@ export default featureToggles;
 // These functions are made available globally so they can be called from the console
 
 /** Enables a feature toggle. Only usable from the console. */
-function enable(featureToggle) {
+function enable(featureToggle: string) {
   if (!(featureToggle in featureToggles)) {
     throw `Feature toggle ${featureToggle} is not defined`;
   }
+  // @ts-ignore
   featureToggles[featureToggle] = true;
   console.log(`Feature toggle '${featureToggle}' enabled`);
 }
 
 /** Disables a feature toggle. Only usable from the console. */
-function disable(featureToggle) {
+function disable(featureToggle: string) {
   if (!(featureToggle in featureToggles)) {
     throw `Feature toggle ${featureToggle} is not defined`;
   }
+  // @ts-ignore
   featureToggles[featureToggle] = false;
   console.log(`Feature toggle '${featureToggle}' disabled`);
 }
 
 // Register enable and disable on the window object so they are accessible from the console
+// @ts-ignore
 window.enable = enable;
+// @ts-ignore
 window.disable = disable;

--- a/web/src/featureToggle.ts
+++ b/web/src/featureToggle.ts
@@ -18,7 +18,8 @@ const featureToggles = reactive({
 
 // Used to narrow string types
 function isToggle(toggle: string): toggle is keyof (typeof featureToggles) {
-  return Object.keys(featureToggles).includes(toggle);
+  // eslint-disable-next-line no-prototype-builtins
+  return featureToggles.hasOwnProperty(toggle);
 }
 
 // Register the feature toggles as computed properties on all components

--- a/web/src/featureToggle.ts
+++ b/web/src/featureToggle.ts
@@ -1,19 +1,29 @@
 /* eslint no-console: 0 */
-/* eslint no-throw-literal: 0 */
 import Vue from 'vue';
+import { reactive } from '@vue/composition-api';
+
+// Declare additions to the global `window` object
+declare global {
+  interface Window {
+    enable: (toggle: string) => void,
+    disable: (toggle: string) => void,
+  }
+}
 
 // Create a component to hold the feature toggles reactively
 // This object can be mutated at runtime to enable/disable feature toggles
-const featureToggles = new Vue({
-  data() {
-    return {
-      DJANGO_API: false,
-    };
-  },
+const featureToggles = reactive({
+  DJANGO_API: false,
 });
+
+// Used to narrow string types
+function isToggle(toggle: string): toggle is keyof (typeof featureToggles) {
+  return Object.keys(featureToggles).includes(toggle);
+}
 
 // Register the feature toggles as computed properties on all components
 // Now feature toggles are available on all components and templates without any imports
+// TODO: Convert this to use composition API.
 Vue.mixin({
   computed: {
     DJANGO_API() {
@@ -29,26 +39,24 @@ export default featureToggles;
 
 /** Enables a feature toggle. Only usable from the console. */
 function enable(featureToggle: string) {
-  if (!(featureToggle in featureToggles)) {
-    throw `Feature toggle ${featureToggle} is not defined`;
+  if (!isToggle(featureToggle)) {
+    throw new Error(`Feature toggle ${featureToggle} is not defined`);
   }
-  // @ts-ignore
+
   featureToggles[featureToggle] = true;
   console.log(`Feature toggle '${featureToggle}' enabled`);
 }
 
 /** Disables a feature toggle. Only usable from the console. */
 function disable(featureToggle: string) {
-  if (!(featureToggle in featureToggles)) {
-    throw `Feature toggle ${featureToggle} is not defined`;
+  if (!isToggle(featureToggle)) {
+    throw new Error(`Feature toggle ${featureToggle} is not defined`);
   }
-  // @ts-ignore
+
   featureToggles[featureToggle] = false;
   console.log(`Feature toggle '${featureToggle}' disabled`);
 }
 
 // Register enable and disable on the window object so they are accessible from the console
-// @ts-ignore
 window.enable = enable;
-// @ts-ignore
 window.disable = disable;

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,21 +1,25 @@
+// Import external packages
 import Vue from 'vue';
-import VueCompositionAPI from '@vue/composition-api';
 import { sync } from 'vuex-router-sync';
 
 // @ts-ignore missing definitions
-import Girder, { vuetify } from '@girder/components/src';
+import { vuetify } from '@girder/components/src';
 import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
 
-import App from '@/App.vue';
+// Import plugins first (order may matter)
+import '@/plugins/composition';
+import '@/plugins/girder';
+
+// Import custom behavior
 import '@/featureToggle';
+import '@/title';
+
+// Import internal items
+import App from '@/App.vue';
 import router from '@/router';
 import store from '@/store';
 import { girderRest, publishRest } from '@/rest';
-import '@/title';
-
-Vue.use(Girder);
-Vue.use(VueCompositionAPI);
 
 Sentry.init({
   dsn: process.env.VUE_APP_SENTRY_DSN,

--- a/web/src/plugins/composition.ts
+++ b/web/src/plugins/composition.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import VueCompositionAPI from '@vue/composition-api';
+
+Vue.use(VueCompositionAPI);

--- a/web/src/plugins/girder.ts
+++ b/web/src/plugins/girder.ts
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+
+// @ts-ignore missing definitions
+import Girder from '@girder/components/src';
+
+Vue.use(Girder);


### PR DESCRIPTION
I saw this as an opportunity to leverage composition API / Typescript, instead of throwing `ts-ignore` around. It may not have been totally necessary (as this specific toggle might not be around for too much longer), but I thought it was a good exercise nonetheless. This also includes a slight reorg to how we use plugins like composition-api and girder.