### PR TITLE
Fix the url in the publishRest.assets method

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -82,7 +82,7 @@ const publishRest = new Vue({
       try {
         const {
           data,
-        } = await client.get(`api/dandisets/${identifier}/versions/${version}/assets`, config);
+        } = await client.get(`dandisets/${identifier}/versions/${version}/assets`, config);
         return data;
       } catch (error) {
         if (error.response && error.response.status === 404) {


### PR DESCRIPTION
This has apparently been broken for a while. The `api/` prefix is no longer required. This will fix the download button for assets in the file browser.