### PR TITLE
Optimize dandisets page

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -179,7 +179,7 @@ export default defineComponent({
 
     const dandisets = computed(() => {
       if (toggles.DJANGO_API) {
-        return djangoDandisetRequest.value?.results.map((dandiset: Dandiset) => dandiset.most_recent_version);
+        return djangoDandisetRequest.value?.results.map((dandiset) => dandiset.most_recent_version);
       }
       return girderDandisetRequest.value?.data || [];
     });

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -141,21 +141,6 @@ export default defineComponent({
       }
     });
 
-    // TODO properly type this
-    // Currently it uses the girderized representation of a dandiset version, which is untyped
-    const mostRecentDandisetVersions: Ref<any | null> = ref(null);
-    watchEffect(async () => {
-      if (djangoDandisetRequest.value === null) {
-        mostRecentDandisetVersions.value = null;
-      } else {
-        mostRecentDandisetVersions.value = await Promise.all(
-          djangoDandisetRequest.value.results.map(
-            (dandiset) => publishRest.mostRecentVersion(dandiset.identifier),
-          ),
-        );
-      }
-    });
-
     // Girder dandiset listing
 
     const listingUrl = computed(() => {
@@ -194,7 +179,7 @@ export default defineComponent({
 
     const dandisets = computed(() => {
       if (toggles.DJANGO_API) {
-        return mostRecentDandisetVersions.value || [];
+        return djangoDandisetRequest.value?.results.map((dandiset: Dandiset) => dandiset.most_recent_version);
       }
       return girderDandisetRequest.value?.data || [];
     });

--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -142,15 +142,13 @@ const publishRest = new Vue({
     async dandisets(params?: any): Promise<AxiosResponse<Paginated<Dandiset>>> {
       const response = await client.get('dandisets/', { params });
       // girderize the most_recent_version field for consumption in DandisetsPage
-      response.data.results = response.data.results.map((dandiset: any) => {
-        return {
-          ...dandiset,
-          most_recent_version: girderize({
-            dandiset,
-            ...dandiset.most_recent_version
-          })
-        };
-      });
+      response.data.results = response.data.results.map((dandiset: any) => ({
+        ...dandiset,
+        most_recent_version: girderize({
+          dandiset,
+          ...dandiset.most_recent_version,
+        }),
+      }));
       return response;
     },
     async createDandiset(name: string, description: string): Promise<AxiosResponse<Dandiset>> {

--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -140,7 +140,18 @@ const publishRest = new Vue({
       return girderize(versions.results[0]);
     },
     async dandisets(params?: any): Promise<AxiosResponse<Paginated<Dandiset>>> {
-      return client.get('dandisets/', { params });
+      const response = await client.get('dandisets/', { params });
+      // girderize the most_recent_version field for consumption in DandisetsPage
+      response.data.results = response.data.results.map((dandiset: any) => {
+        return {
+          ...dandiset,
+          most_recent_version: girderize({
+            dandiset,
+            ...dandiset.most_recent_version
+          })
+        };
+      });
+      return response;
     },
     async createDandiset(name: string, description: string): Promise<AxiosResponse<Dandiset>> {
       const metadata = { name, description };

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -9,6 +9,8 @@ export interface Dandiset {
   identifier: string,
   created: string,
   modified: string,
+  // TODO most_recent_version is girderized, it should have type Version
+  most_recent_version?: any,
 }
 
 export interface Version {


### PR DESCRIPTION
Use the `most_recent_version` field now provided by the API. Most of this will need to be refactored after flipping the DJANGO_API toggle.