### PR TITLE
Fix call to stats endpoint

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -170,7 +170,7 @@ const publishRest = new Vue({
       return data;
     },
     async stats() {
-      const { data } = await client.get('api/stats/');
+      const { data } = await client.get('stats/');
       return data;
     },
     assetDownloadURI(asset: Asset) {


### PR DESCRIPTION
The stats bar was calling /api/api/stats, probably due to some
overlooked merge conflict.