### PR TITLE
Fix django-api sync workflow

### DIFF
--- a/.github/workflows/sync-django-api.yml
+++ b/.github/workflows/sync-django-api.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: django-api
+          force: true


### PR DESCRIPTION
Need the `force` option since it rewrites the last commit each time.