### PR TITLE
Add fetch-depth option to checkout action

### DIFF
--- a/.github/workflows/sync-django-api.yml
+++ b/.github/workflows/sync-django-api.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: django-api
+          fetch-depth: 0
 
       - run: git fetch
       - run: git rebase origin/master


### PR DESCRIPTION
This should hopefully stop the merge conflicts when rebasing in github actions