### PR TITLE
Do not assume / root on the file browser

### DIFF
--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -22,11 +22,12 @@
               :to="{ name: 'fileBrowser', query: { location: rootDirectory } }"
               style="text-decoration: none;"
             >
-              {{ rootDirectory }}
+              <v-icon>mdi-home</v-icon>
             </router-link>
 
             <template v-for="(part, i) in splitLocation">
               <template v-if="part">
+                /
                 <router-link
                   :key="part"
                   :to="{ name: 'fileBrowser', query: { location: locationSlice(i) } }"
@@ -88,7 +89,7 @@ import { publishRest } from '@/rest';
 
 const isFolder = (pathName) => (pathName.slice(-1) === '/');
 const parentDirectory = '..';
-const rootDirectory = '/';
+const rootDirectory = '';
 
 export default {
   name: 'PublishFileBrowser',


### PR DESCRIPTION
dandi-cli uses asset paths with no slash prefix (i.e. `folder/file.txt`, not `/folder/file.txt`), but the FileBrowser widget assumed an initial slash. This removes that assumption and adds a :house: icon to return the user to the root of the dandiset, since the `/` that originally returned the user to the root no longer applies.

Fixes #554 