### PR TITLE
Enable app startup with DJANGO_API feature flag set

### DIFF
--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -13,7 +13,7 @@ import '@/plugins/composition';
 import '@/plugins/girder';
 
 // Import custom behavior
-import '@/featureToggle';
+import featureToggles from '@/featureToggle';
 import '@/title';
 
 // Import internal items
@@ -29,7 +29,10 @@ Sentry.init({
 
 sync(store, router);
 
-Promise.all([publishRest.restoreLogin(), girderRest.fetchUser()]).then(() => {
+// Get login info from the correct server.
+const loginCall = featureToggles.DJANGO_API ? publishRest.restoreLogin() : girderRest.fetchUser();
+
+loginCall.then(() => {
   new Vue({
     setup() {
       provide('store', store);


### PR DESCRIPTION
Even with the DJANGO_API feature flag set to `true` in the source code, the app will not correctly start up in dev without both a Girder and a Django server running. This is because the app startup routine was unconditionally asking for login status from both servers. This PR uses the feature flag to hit one or the other of the two servers.