### PR TITLE
Add a delete asset button

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -189,6 +189,9 @@ const publishRest = new Vue({
       const { uuid } = asset;
       return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;
     },
+    async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
+      return client.delete(`${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}`);
+    },
   },
 });
 

--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -190,7 +190,7 @@ const publishRest = new Vue({
       return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/download`;
     },
     async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
-      return client.delete(`${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}`);
+      return client.delete(`${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/`);
     },
   },
 });

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -101,6 +101,7 @@
 
               <v-list-item-action>
                 <v-btn
+                  v-if="!item.folder"
                   icon
                   @click="openDialog(item.name)"
                 >

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -1,5 +1,38 @@
 <template>
   <v-container>
+    <v-dialog
+      v-model="dialog.active"
+      persistent
+      max-width="60vh"
+    >
+      <v-card>
+        <v-card-title class="headline">
+          Really delete this asset?
+        </v-card-title>
+
+        <v-card-text>
+          Are you sure you want to delete asset <span
+          class="font-italic">{{dialog.name}}</span>?
+            <strong>This action cannot be undone.</strong>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn
+            @click="dialog.active = false"
+          >
+            Cancel
+          </v-btn>
+          <v-btn
+            color="error"
+            @click="deleteAsset(dialog.name)"
+          >
+            Yes
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
     <v-row>
       <v-col :cols="12">
         <v-card>
@@ -67,45 +100,14 @@
               <v-spacer />
 
               <v-list-item-action>
-                <v-dialog
-                  v-model="deleteConfirmationDialog"
-                  persistent
-                  max-width="60vh"
+                <v-btn
+                  icon
+                  @click="openDialog(item.name)"
                 >
-                  <template v-slot:activator="{ on }">
-                    <v-btn
-                      icon
-                      v-on="on"
-                    >
-                      <v-icon color="error">
-                        mdi-delete
-                      </v-icon>
-                    </v-btn>
-                  </template>
-                  <v-card>
-                    <v-card-title class="headline">
-                      Really delete this asset?
-                    </v-card-title>
-                    <v-card-text>
-                      Are you sure you want to delete this asset? <strong>This
-                        action cannot be undone.</strong>
-                    </v-card-text>
-                    <v-card-actions>
-                      <v-spacer />
-                      <v-btn
-                        @click="deleteConfirmationDialog = false"
-                      >
-                        Cancel
-                      </v-btn>
-                      <v-btn
-                        color="error"
-                        @click="deleteAsset(item.name)"
-                      >
-                        Yes
-                      </v-btn>
-                    </v-card-actions>
-                  </v-card>
-                </v-dialog>
+                  <v-icon color="error">
+                    mdi-delete
+                  </v-icon>
+                </v-btn>
               </v-list-item-action>
 
               <v-list-item-action v-if="itemDownloads[item.name]">
@@ -153,7 +155,10 @@ export default {
       loading: false,
       itemDownloads: {},
       itemDeletes: {},
-      deleteConfirmationDialog: false,
+      dialog: {
+        active: false,
+        name: '',
+      },
     };
   },
   computed: {
@@ -247,6 +252,11 @@ export default {
       }
     },
 
+    openDialog(name) {
+      this.dialog.name = name;
+      this.dialog.active = true;
+    },
+
     async deleteAsset(name) {
       const asset = this.itemDeletes[name];
       if (asset !== undefined) {
@@ -257,7 +267,7 @@ export default {
         // Recompute the items to display in the browser.
         this.$asyncComputed.items.update();
       }
-      this.deleteConfirmationDialog = false;
+      this.dialog.active = false;
     },
   },
 };

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -167,6 +167,19 @@ export default {
     splitLocation() {
       return this.location.split('/');
     },
+
+    me() {
+      return publishRest.user ? publishRest.user.username : null;
+    },
+
+    isAdmin() {
+      return this.me && publishRest.user.admin;
+    },
+
+    isOwner() {
+      return this.me && this.owners.includes(this.me);
+    },
+
     ...mapState('dandiset', ['publishDandiset']),
   },
   asyncComputed: {
@@ -255,12 +268,7 @@ export default {
     },
 
     showDelete(item) {
-      const me = publishRest.user ? publishRest.user.username : null;
-
-      const isAdmin = me && publishRest.user.admin;
-      const isOwner = me && this.owners.includes(me);
-
-      return !item.folder && (isAdmin || isOwner);
+      return !item.folder && (this.isAdmin || this.isOwner);
     },
 
     openDialog(name) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -12,8 +12,9 @@
 
         <v-card-text>
           Are you sure you want to delete asset <span
-          class="font-italic">{{dialog.name}}</span>?
-            <strong>This action cannot be undone.</strong>
+            class="font-italic"
+          >{{ dialog.name }}</span>?
+          <strong>This action cannot be undone.</strong>
         </v-card-text>
 
         <v-card-actions>

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -247,11 +247,15 @@ export default {
       }
     },
 
-    deleteAsset(name) {
+    async deleteAsset(name) {
       const asset = this.itemDeletes[name];
       if (asset !== undefined) {
+        // Delete the asset on the server.
         const { identifier, version, uuid } = asset;
-        publishRest.deleteAsset(identifier, version, uuid);
+        await publishRest.deleteAsset(identifier, version, uuid);
+
+        // Recompute the items to display in the browser.
+        this.$asyncComputed.items.update();
       }
       this.deleteConfirmationDialog = false;
     },

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -112,10 +112,10 @@
                 </v-btn>
               </v-list-item-action>
 
-              <v-list-item-action v-if="itemDownload(item.name)">
+              <v-list-item-action v-if="itemData[item.name]">
                 <v-btn
                   icon
-                  :href="itemDownload(item.name)"
+                  :href="itemData[item.name].download"
                 >
                   <v-icon color="primary">
                     mdi-download
@@ -262,10 +262,6 @@ export default {
     openDialog(name) {
       this.dialogName = name;
       this.dialogActive = true;
-    },
-
-    itemDownload(name) {
-      return this.itemData[name] && this.itemData[name].download;
     },
 
     async deleteAsset(name) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -101,7 +101,7 @@
 
               <v-list-item-action>
                 <v-btn
-                  v-if="!item.folder"
+                  v-if="showDelete(item)"
                   icon
                   @click="openDialog(item.name)"
                 >
@@ -155,6 +155,7 @@ export default {
       location: rootDirectory,
       itemDownloads: {},
       itemDeletes: {},
+      owners: [],
       dialog: {
         active: false,
         name: '',
@@ -173,6 +174,7 @@ export default {
         const { version, identifier, location } = this;
 
         const data = await publishRest.assetPaths(identifier, version, location);
+        this.owners = (await publishRest.owners(identifier)).data;
 
         let mapped = data.map((x) => ({ name: x, folder: isFolder(x) }));
         if (location !== rootDirectory && mapped.length) {
@@ -248,6 +250,10 @@ export default {
       } else {
         this.location = `${this.location}${name}`;
       }
+    },
+
+    showDelete(item) {
+      return !item.folder && publishRest.user.admin || this.owners.includes(publishRest.user.username);
     },
 
     openDialog(name) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -65,6 +65,18 @@
               </v-icon>
               {{ item.name }}
               <v-spacer />
+
+              <v-list-item-action>
+                <v-btn
+                  icon
+                  @click="deleteAsset"
+                >
+                  <v-icon color="error">
+                    mdi-delete
+                  </v-icon>
+                </v-btn>
+              </v-list-item-action>
+
               <v-list-item-action v-if="itemDownloads[item.name]">
                 <v-btn
                   icon
@@ -193,6 +205,10 @@ export default {
       } else {
         this.location = `${this.location}${name}`;
       }
+    },
+
+    deleteAsset() {
+      console.log('delete button');
     },
   },
 };

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -99,7 +99,7 @@
                       </v-btn>
                       <v-btn
                         color="error"
-                        @click="deleteAsset"
+                        @click="deleteAsset(item.name)"
                       >
                         Yes
                       </v-btn>
@@ -152,6 +152,7 @@ export default {
       location: rootDirectory,
       loading: false,
       itemDownloads: {},
+      itemDeletes: {},
       deleteConfirmationDialog: false,
     };
   },
@@ -200,8 +201,9 @@ export default {
         return;
       }
 
-      // Create the download link in itemDownloads for each item in items
+      // Create download and delete links in local data for each item in items
       this.itemDownloads = {};
+      this.itemDeletes = {};
       const { identifier, version, location } = this;
 
       items.filter((x) => !x.folder).map(async (item) => {
@@ -215,6 +217,12 @@ export default {
           item.name,
           publishRest.assetDownloadURI(identifier, version, asset),
         );
+
+        this.$set(this.itemDeletes, item.name, {
+          identifier,
+          version,
+          uuid: asset.uuid,
+        });
       });
     },
     $route: {
@@ -239,8 +247,11 @@ export default {
       }
     },
 
-    deleteAsset() {
-      console.log('delete button');
+    deleteAsset(name) {
+      const asset = this.itemDeletes[name];
+      if (asset !== undefined) {
+        console.log('deleteAsset:', asset);
+      }
       this.deleteConfirmationDialog = false;
     },
   },

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -250,7 +250,8 @@ export default {
     deleteAsset(name) {
       const asset = this.itemDeletes[name];
       if (asset !== undefined) {
-        console.log('deleteAsset:', asset);
+        const { identifier, version, uuid } = asset;
+        publishRest.deleteAsset(identifier, version, uuid);
       }
       this.deleteConfirmationDialog = false;
     },

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-dialog
-      v-model="dialog.active"
+      v-model="dialogActive"
       persistent
       max-width="60vh"
     >
@@ -13,20 +13,20 @@
         <v-card-text>
           Are you sure you want to delete asset <span
             class="font-italic"
-          >{{ dialog.name }}</span>?
+          >{{ dialogName }}</span>?
           <strong>This action cannot be undone.</strong>
         </v-card-text>
 
         <v-card-actions>
           <v-spacer />
           <v-btn
-            @click="dialog.active = false"
+            @click="dialogActive = false"
           >
             Cancel
           </v-btn>
           <v-btn
             color="error"
-            @click="deleteAsset(dialog.name)"
+            @click="deleteAsset(dialogName)"
           >
             Yes
           </v-btn>
@@ -157,10 +157,8 @@ export default {
       itemDownloads: {},
       itemDeletes: {},
       owners: [],
-      dialog: {
-        active: false,
-        name: '',
-      },
+      dialogActive: false,
+      dialogName: '',
     };
   },
   computed: {
@@ -272,8 +270,8 @@ export default {
     },
 
     openDialog(name) {
-      this.dialog.name = name;
-      this.dialog.active = true;
+      this.dialogName = name;
+      this.dialogActive = true;
     },
 
     async deleteAsset(name) {
@@ -286,7 +284,7 @@ export default {
         // Recompute the items to display in the browser.
         this.$asyncComputed.items.update();
       }
-      this.dialog.active = false;
+      this.dialogActive = false;
     },
   },
 };

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -174,7 +174,8 @@ export default {
         const { version, identifier, location } = this;
 
         const data = await publishRest.assetPaths(identifier, version, location);
-        this.owners = (await publishRest.owners(identifier)).data;
+        this.owners = (await publishRest.owners(identifier)).data
+          .map((x) => x.username);
 
         let mapped = data.map((x) => ({ name: x, folder: isFolder(x) }));
         if (location !== rootDirectory && mapped.length) {
@@ -253,8 +254,10 @@ export default {
     },
 
     showDelete(item) {
-      const isAdmin = publishRest.user && publishRest.user.admin;
-      const isOwner = publishRest.user && this.owners.map(x => x.username).includes(publishRest.user.username);
+      const me = publishRest.user ? publishRest.user.username : null;
+
+      const isAdmin = me && publishRest.user.admin;
+      const isOwner = me && this.owners.includes(me);
 
       return !item.folder && (isAdmin || isOwner);
     },

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -229,11 +229,7 @@ export default {
 
         this.$set(this.itemData, item.name, {
           download: publishRest.assetDownloadURI(identifier, version, asset),
-          delete: {
-            identifier,
-            version,
-            uuid: asset.uuid,
-          },
+          uuid: asset.uuid,
         });
       });
     },
@@ -272,16 +268,11 @@ export default {
       return this.itemData[name] && this.itemData[name].download;
     },
 
-    itemDelete(name) {
-      return this.itemData[name] && this.itemData[name].delete;
-    },
-
     async deleteAsset(name) {
-      const asset = this.itemDelete(name);
-      if (asset !== undefined) {
+      const uuid = this.itemData[name] && this.itemData[name].uuid;
+      if (uuid !== undefined) {
         // Delete the asset on the server.
-        const { identifier, version, uuid } = asset;
-        await publishRest.deleteAsset(identifier, version, uuid);
+        await publishRest.deleteAsset(this.identifier, this.version, uuid);
 
         // Recompute the items to display in the browser.
         this.$asyncComputed.items.update();

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -253,7 +253,10 @@ export default {
     },
 
     showDelete(item) {
-      return !item.folder && publishRest.user.admin || this.owners.includes(publishRest.user.username);
+      const isAdmin = publishRest.user && publishRest.user.admin;
+      const isOwner = publishRest.user && this.owners.map(x => x.username).includes(publishRest.user.username);
+
+      return !item.folder && (isAdmin || isOwner);
     },
 
     openDialog(name) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -74,7 +74,7 @@
             </template>
           </v-card-title>
           <v-progress-linear
-            v-if="loading"
+            v-if="$asyncComputed.items.updating"
             indeterminate
           />
           <v-divider v-else />
@@ -153,7 +153,6 @@ export default {
     return {
       rootDirectory,
       location: rootDirectory,
-      loading: false,
       itemDownloads: {},
       itemDeletes: {},
       dialog: {
@@ -173,7 +172,6 @@ export default {
       async get() {
         const { version, identifier, location } = this;
 
-        this.loading = true;
         const data = await publishRest.assetPaths(identifier, version, location);
 
         let mapped = data.map((x) => ({ name: x, folder: isFolder(x) }));
@@ -184,7 +182,6 @@ export default {
           ];
         }
 
-        this.loading = false;
         return mapped;
       },
       default: null,

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -67,14 +67,45 @@
               <v-spacer />
 
               <v-list-item-action>
-                <v-btn
-                  icon
-                  @click="deleteAsset"
+                <v-dialog
+                  v-model="deleteConfirmationDialog"
+                  persistent
+                  max-width="60vh"
                 >
-                  <v-icon color="error">
-                    mdi-delete
-                  </v-icon>
-                </v-btn>
+                  <template v-slot:activator="{ on }">
+                    <v-btn
+                      icon
+                      v-on="on"
+                    >
+                      <v-icon color="error">
+                        mdi-delete
+                      </v-icon>
+                    </v-btn>
+                  </template>
+                  <v-card>
+                    <v-card-title class="headline">
+                      Really delete this asset?
+                    </v-card-title>
+                    <v-card-text>
+                      Are you sure you want to delete this asset? <strong>This
+                        action cannot be undone.</strong>
+                    </v-card-text>
+                    <v-card-actions>
+                      <v-spacer />
+                      <v-btn
+                        @click="deleteConfirmationDialog = false"
+                      >
+                        Cancel
+                      </v-btn>
+                      <v-btn
+                        color="error"
+                        @click="deleteAsset"
+                      >
+                        Yes
+                      </v-btn>
+                    </v-card-actions>
+                  </v-card>
+                </v-dialog>
               </v-list-item-action>
 
               <v-list-item-action v-if="itemDownloads[item.name]">
@@ -121,6 +152,7 @@ export default {
       location: rootDirectory,
       loading: false,
       itemDownloads: {},
+      deleteConfirmationDialog: false,
     };
   },
   computed: {
@@ -209,6 +241,7 @@ export default {
 
     deleteAsset() {
       console.log('delete button');
+      this.deleteConfirmationDialog = false;
     },
   },
 };


### PR DESCRIPTION
This PR adds a "delete asset" button to the dandiset file browser. It includes a confirmation dialog, and it takes care to update the asset list after deletion succeeds.

This is pretty simple, so it may need things like error handling, or a better confirmation dialog. But it's at least a start.

One possible pitfall: I un-async-computified the `items` calculation. If there's a better way to accomplish the asset list refresh, please let me know.

Closes #576 