### PR TITLE
Switch to version info endpoint

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -117,7 +117,7 @@ const publishRest = new Vue({
     },
     async specificVersion(identifier: string, version: string) {
       try {
-        const { data } = await client.get(`dandisets/${identifier}/versions/${version}/`);
+        const { data } = await client.get(`dandisets/${identifier}/versions/${version}/info/`);
         return girderize(data);
       } catch (error) {
         if (error.response && error.response.status === 404) {


### PR DESCRIPTION
The version detail endpoint
(`/dandisets/{dandiset_id}/versions/{version_id}`) has been changed to
only return the version metadata. To avoid changing everything in the
frontend to use the metadata schema, a new version action `info` was
added.

Change `specificVersion` to use `/versions/{version_id}/info/`.

Tied to dandi/dandi-api#236