### PR TITLE
Add staging branch deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,9 @@ command = "yarn run build"
   VUE_APP_OAUTH_CLIENT_ID = "Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl"
   VUE_APP_PUBLISH_API_ROOT = "https://api.dandiarchive.org/api/"
   VUE_APP_SENTRY_DSN = "https://425b9a012300493d867e97785fae7b88@o308436.ingest.sentry.io/5196549"
+
+[context.staging]
+
+  [context.staging.environment]
+  VUE_APP_OAUTH_API_ROOT = "https://api-staging.dandiarchive.org/oauth/"
+  VUE_APP_PUBLISH_API_ROOT = "https://api-staging.dandiarchive.org/api/"


### PR DESCRIPTION
`netlify.toml` assumes that `[context.staging]` means that you want another deployment on the branch `staging`, so we need to maintain a `staging` branch in this repo going forward for this deployment to be useful.