### PR TITLE
Switch between "view" and "edit" metadata button

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -92,7 +92,7 @@ import { mapState } from 'vuex';
 import DandisetSearchField from '@/components/DandisetSearchField.vue';
 import { draftVersion } from '@/utils/constants';
 import toggles from '@/featureToggle';
-import { user } from '@/rest';
+import { publishRest, user } from '@/rest';
 import MetaEditor from './MetaEditor.vue';
 import Meditor from './Meditor.vue';
 import DandisetMain from './DandisetMain.vue';

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -8,6 +8,7 @@
         v-if="DJANGO_API"
         :schema="schema"
         :model="meta"
+        :readonly="readonly"
         @close="edit = false"
       />
       <meta-editor
@@ -69,7 +70,7 @@
             <DandisetMain
               :schema="schema"
               :meta="meta"
-              @edit="edit = true"
+              @edit="edit = true; readonly = $event"
             />
           </v-col>
           <v-col
@@ -118,6 +119,7 @@ export default {
   data() {
     return {
       edit: false,
+      readonly: false,
       detailsPanel: true,
     };
   },

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -67,7 +67,7 @@
         </v-btn>
         <v-btn
           text
-          @click="$emit('edit', !userCanModifyDandiset)"
+          @click="$emit('edit')"
         >
           <v-icon
             color="primary"
@@ -175,6 +175,10 @@ export default {
       type: Object,
       required: true,
     },
+    userCanModifyDandiset: {
+      type: Boolean,
+      required: true,
+    },
   },
   data() {
     return {
@@ -254,19 +258,6 @@ export default {
     ...mapGetters('dandiset', ['version']),
   },
   asyncComputed: {
-    userCanModifyDandiset: {
-      async get() {
-        if (this.user.admin) {
-          return true;
-        }
-
-        const { identifier } = this.publishDandiset.meta.dandiset;
-        const { data: owners } = await publishRest.owners(identifier);
-        const userExists = owners.find((owner) => owner.username === this.user.username);
-        return !!userExists;
-      },
-      default: false,
-    },
     lockOwner: {
       async get() {
         if (toggles.DJANGO_API) {

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -65,6 +65,18 @@
           </v-icon>
           View Data
         </v-btn>
+        <v-btn
+          text
+          @click="$emit('edit', !userCanModifyDandiset)"
+        >
+          <v-icon
+            color="primary"
+            class="mr-2"
+          >
+            {{ metadataButtonIcon }}
+          </v-icon>
+          {{ metadataButtonText }}
+        </v-btn>
         <template v-if="!DJANGO_API || publishDandiset.version == 'draft'">
           <v-tooltip
             left
@@ -72,19 +84,6 @@
           >
             <template v-slot:activator="{ on }">
               <div v-on="on">
-                <v-btn
-                  text
-                  :disabled="editDisabledMessage !== null"
-                  @click="$emit('edit')"
-                >
-                  <v-icon
-                    color="primary"
-                    class="mr-2"
-                  >
-                    mdi-pencil
-                  </v-icon>
-                  Edit metadata
-                </v-btn>
                 <!-- TODO for now only admins can publish -->
                 <v-btn
                   v-if="DJANGO_API"
@@ -219,6 +218,12 @@ export default {
       }
 
       return null;
+    },
+    metadataButtonText() {
+      return this.userCanModifyDandiset ? 'Edit metadata' : 'View metadata';
+    },
+    metadataButtonIcon() {
+      return this.userCanModifyDandiset ? 'mdi-pencil' : 'mdi-eye';
     },
     fileBrowserLink() {
       if (toggles.DJANGO_API) {

--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -229,7 +229,7 @@ export default defineComponent({
       return undefined;
     }
 
-    const options = computed(() => ({
+    const CommonVJSFOptions = computed(() => ({
       initialValidation: 'all',
       disableAll: props.readonly,
     }));
@@ -301,7 +301,7 @@ export default defineComponent({
       download,
       sectionButtonColor,
 
-      CommonVJSFOptions: options,
+      CommonVJSFOptions,
 
       setComplexModelProp,
     };

--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -68,6 +68,7 @@
                   color="primary"
                   v-on="on"
                   @click="save"
+                  :disabled="readonly"
                 >
                   <v-icon>
                     mdi-content-save
@@ -180,10 +181,6 @@ function renderField(fieldSchema: JSONSchema7) {
   return true;
 }
 
-const CommonVJSFOptions = {
-  initialValidation: 'all',
-};
-
 export default defineComponent({
   name: 'Meditor',
   components: { VJsf },
@@ -194,6 +191,10 @@ export default defineComponent({
     },
     model: {
       type: Object as PropType<DandiModel>,
+      required: true,
+    },
+    readonly: {
+      type: Boolean,
       required: true,
     },
   },
@@ -228,6 +229,10 @@ export default defineComponent({
       return undefined;
     }
 
+    const options = computed(() => ({
+      initialValidation: 'all',
+      disableAll: props.readonly,
+    }));
     const publishDandiset = computed(() => store.state.dandiset.publishDandiset);
     const id = computed(() => publishDandiset.value?.meta.dandiset.identifier || null);
     function setDandiset(payload: any) {
@@ -296,7 +301,7 @@ export default defineComponent({
       download,
       sectionButtonColor,
 
-      CommonVJSFOptions,
+      CommonVJSFOptions: options,
 
       setComplexModelProp,
     };

--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -195,7 +195,7 @@ export default defineComponent({
     },
     readonly: {
       type: Boolean,
-      required: true,
+      default: true,
     },
   },
   setup(props, ctx) {


### PR DESCRIPTION
This changes the behavior of the "edit metadata" button. Formerly, that button was available for owners of a dandiset, and admins, and was disabled for all others. Now, instead of disabling the button, it instead shows "view metadata", and leads to an instance of the meditor with the underlying component set to show all its data in a read only mode.

Closes #647