### PR TITLE
Use better icons in breadcrumb

### DIFF
--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -55,6 +55,7 @@
             <router-link
               :to="{ name: 'fileBrowser', query: { location: rootDirectory } }"
               style="text-decoration: none;"
+              class="mx-2"
             >
               {{ identifier }}
             </router-link>

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -46,7 +46,7 @@
                 params: { identifier, version },
               }"
             >
-              <v-icon>mdi-jellyfish</v-icon>
+              <v-icon>mdi-home</v-icon>
             </v-btn>
             <v-divider
               vertical
@@ -56,7 +56,7 @@
               :to="{ name: 'fileBrowser', query: { location: rootDirectory } }"
               style="text-decoration: none;"
             >
-              <v-icon>mdi-home</v-icon>
+              {{ identifier }}
             </router-link>
 
             <template v-for="(part, i) in splitLocation">


### PR DESCRIPTION
Two related changes in the dandiset file browser view:
- replace the jellyfish icon with a home icon
- replace the existing home icon with a link showing the dandiset ID

@bendichter you can see what this looks like at the Netlify preview here: https://deploy-preview-656--gui-dandiarchive-org.netlify.app/#/dandiset/000003/draft/files

Closes #655.