### PR TITLE
Revert VJSF version bump

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "1.25.0-beta.12",
+    "@koumoul/vjsf": "1.21.0",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1001,19 +1001,16 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@1.25.0-beta.12":
-  version "1.25.0-beta.12"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-1.25.0-beta.12.tgz#87f33375650b5552fc046916b4ce37303f89cdc0"
-  integrity sha512-i1EWUFFmGYNfqkvH9w3L4+hZmKI8fYnuNyRlabdpr/ythjoH4G3hTfjRcLlHsyAbfxeevv6Mc7A5TafPrJqOhw==
+"@koumoul/vjsf@1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-1.21.0.tgz#f281f967b296a9c8672ab9b04a7d03c3c55eae1f"
+  integrity sha512-Juq9QY1zuImkM4zInN3TuKwUC0Q79sZlZEcQM9ZMoHDdtzIu/Kk5927U/UGXv5MQSnnWkfTaTE5RePO1PYyR0g==
   dependencies:
     "@mdi/js" "^5.5.55"
     ajv "^6.12.0"
     debounce "^1.2.0"
-    fast-copy "^2.1.1"
-    fast-equals "^2.0.0"
     markdown-it "^8.4.2"
     match-all "^1.2.5"
-    object-hash "^2.1.1"
     property-expr "^1.5.1"
     vuedraggable "^2.24.3"
 
@@ -4308,20 +4305,10 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-copy@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.1.tgz#f5cbcf2df64215e59b8e43f0b2caabc19848083a"
-  integrity sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==
-
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-equals@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.3.tgz#7039b0a039909f345a2ce53f6202a14e5f392efc"
-  integrity sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -6625,11 +6612,6 @@ object-hash@^1.1.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
-
-object-hash@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.1.1.tgz#9447d0279b4fcf80cff3259bf66a1dc73afabe09"
-  integrity sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==
 
 object-inspect@^1.9.0:
   version "1.10.3"


### PR DESCRIPTION
Fixes #681

If we want to bump the VJSF version we can do that in a separate PR (for example `v1.23.0` seems to work fine). However this will fix the immediate issue.

