### PR TITLE
Validation status

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -12,7 +12,16 @@ const publishApiRoot = process.env.VUE_APP_PUBLISH_API_ROOT.endsWith('/')
 
 export function girderize(publishedDandiset: Version) {
   const { // eslint-disable-next-line camelcase
-    created, modified, dandiset, version, metadata, name, size, asset_count,
+    created,
+    modified,
+    dandiset,
+    version,
+    metadata,
+    name,
+    size,
+    asset_count,
+    status,
+    validation_error,
   } = publishedDandiset;
   return {
     created,
@@ -22,6 +31,8 @@ export function girderize(publishedDandiset: Version) {
     lowerName: name,
     bytes: size,
     items: asset_count,
+    status,
+    validationError: validation_error,
     meta: {
       dandiset: {
         ...metadata,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -18,6 +18,8 @@ export interface Version {
   name: string,
   asset_count: number,
   size: number,
+  status: 'Pending' | 'Validating' | 'Valid' | 'Invalid',
+  validation_error?: string,
   created: string,
   modified: string,
   dandiset: Dandiset,

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -205,12 +205,13 @@ export default {
       if (!this.userCanModifyDandiset) {
         return 'You do not have permission to edit this dandiset.';
       }
-
       if (this.publishDandiset.status === 'Invalid') {
         return this.publishDandiset.validationError;
-      } if (this.publishDandiset.status === 'Pending') {
+      }
+      if (this.publishDandiset.status === 'Pending') {
         return 'This dandiset has not yet been validated.';
-      } if (this.publishDandiset.status === 'Validating') {
+      }
+      if (this.publishDandiset.status === 'Validating') {
         return 'Currently validating this dandiset.';
       }
 

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -83,7 +83,7 @@
         <template v-if="!DJANGO_API || publishDandiset.version == 'draft'">
           <v-tooltip
             left
-            :disabled="editDisabledMessage === null"
+            :disabled="publishDisabledMessage === null"
           >
             <template #activator="{ on }">
               <div v-on="on">
@@ -92,7 +92,7 @@
                   v-if="DJANGO_API"
                   id="publish"
                   text
-                  :disabled="editDisabledMessage !== null || !user || !user.admin"
+                  :disabled="publishDisabledMessage !== null || !user || !user.admin"
                   @click="publish"
                 >
                   <v-icon
@@ -105,7 +105,7 @@
                 </v-btn>
               </div>
             </template>
-            {{ editDisabledMessage }}
+            {{ publishDisabledMessage }}
           </v-tooltip>
         </template>
       </v-row>
@@ -197,32 +197,21 @@ export default {
   computed: {
     loggedIn,
     user,
-    editDisabledMessage() {
+    publishDisabledMessage() {
       if (!this.loggedIn) {
         return 'You must be logged in to edit.';
       }
 
-      const permissionsMessage = 'You do not have permission to edit this dandiset.';
+      if (!this.userCanModifyDandiset) {
+        return 'You do not have permission to edit this dandiset.';
+      }
 
-      if (toggles.DJANGO_API) {
-        if (!this.userCanModifyDandiset) {
-          return permissionsMessage;
-        }
-      } else {
-        if (!this.girderDandiset) {
-          return null;
-        }
-
-        if (this.girderDandiset._accessLevel < 1) {
-          return permissionsMessage;
-        }
-
-        if (this.lockOwner != null) {
-          if (this.lockOwner.email === 'publish@dandiarchive.org') {
-            return 'A publish is currently in progress';
-          }
-          return `This dandiset is currently locked by ${this.lockOwner.firstName} ${this.lockOwner.lastName}`;
-        }
+      if (this.publishDandiset.status === 'Invalid') {
+        return this.publishDandiset.validationError;
+      } if (this.publishDandiset.status === 'Pending') {
+        return 'This dandiset has not yet been validated.';
+      } if (this.publishDandiset.status === 'Validating') {
+        return 'Currently validating this dandiset.';
       }
 
       return null;


### PR DESCRIPTION
Add `status` and `validation_error` to `Version` from the API.

Use `status` to disable the Publish button with an informative error if
the metadata is not valid.

Also rip out a snippet of old girder code.

This should actually be safe to merge into master now. If `status` is not present in the API response, none of the status checks pass, which results in the system behaving exactly as it does now (publish is allowed for all admins).