### PR TITLE
Fix small UX issues

### DIFF
--- a/web/src/components/DandisetSearchField.vue
+++ b/web/src/components/DandisetSearchField.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-form @submit="performSearch">
+  <v-form
+    width="100vh"
+    @submit="performSearch"
+  >
     <v-text-field
       :value="$route.query.search"
       label="Search Dandisets by name, description, identifier, or contributor name"

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-page-title="pageTitle">
     <v-toolbar color="grey darken-2 white--text">
-      <v-toolbar-title class="d-none d-md-block mx-8">
+      <v-toolbar-title class="d-none d-md-block">
         {{ title }}
       </v-toolbar-title>
       <v-divider

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -35,13 +35,6 @@
           v-if="!currentDandiset || loading"
           indeterminate
         />
-        <v-row v-if="$vuetify.breakpoint.smAndDown">
-          <v-col
-            cols="12"
-          >
-            <DandisetDetails />
-          </v-col>
-        </v-row>
         <v-row>
           <v-col>
             <DandisetMain
@@ -54,6 +47,13 @@
           <v-col
             v-if="!$vuetify.breakpoint.smAndDown"
             cols="3"
+          >
+            <DandisetDetails />
+          </v-col>
+        </v-row>
+        <v-row v-if="$vuetify.breakpoint.smAndDown">
+          <v-col
+            cols="12"
           >
             <DandisetDetails />
           </v-col>

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -20,7 +20,7 @@
     </template>
     <template v-else>
       <v-toolbar class="grey darken-2 white--text">
-        <v-toolbar-title class="d-none d-md-block mx-8">
+        <v-toolbar-title class="d-none d-md-block">
           Dandiset Dashboard
         </v-toolbar-title>
         <v-progress-circular

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -20,12 +20,6 @@
     </template>
     <template v-else>
       <v-toolbar class="grey darken-2 white--text">
-        <v-progress-circular
-          v-if="!currentDandiset || loading"
-          indeterminate
-          class="ml-3"
-        />
-        <v-spacer />
         <DandisetSearchField />
       </v-toolbar>
       <v-container
@@ -33,6 +27,10 @@
         fluid
         class="grey lighten-4"
       >
+        <v-progress-linear
+          v-if="!currentDandiset || loading"
+          indeterminate
+        />
         <v-row v-if="$vuetify.breakpoint.smAndDown">
           <v-col
             cols="12"

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -27,19 +27,6 @@
         />
         <v-spacer />
         <DandisetSearchField />
-        <v-btn
-          icon
-          @click="detailsPanel = !detailsPanel"
-        >
-          <v-icon color="white">
-            <template v-if="detailsPanel">
-              mdi-chevron-up
-            </template>
-            <template v-else>
-              mdi-chevron-down
-            </template>
-          </v-icon>
-        </v-btn>
       </v-toolbar>
       <v-container
         v-if="currentDandiset"
@@ -48,7 +35,6 @@
       >
         <v-row v-if="$vuetify.breakpoint.smAndDown">
           <v-col
-            v-if="detailsPanel"
             cols="12"
           >
             <DandisetDetails />
@@ -64,7 +50,7 @@
             />
           </v-col>
           <v-col
-            v-if="detailsPanel && !$vuetify.breakpoint.smAndDown"
+            v-if="!$vuetify.breakpoint.smAndDown"
             cols="3"
           >
             <DandisetDetails />
@@ -111,7 +97,6 @@ export default {
     return {
       edit: false,
       readonly: false,
-      detailsPanel: true,
     };
   },
   computed: {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -20,9 +20,6 @@
     </template>
     <template v-else>
       <v-toolbar class="grey darken-2 white--text">
-        <v-toolbar-title class="d-none d-md-block">
-          Dandiset Dashboard
-        </v-toolbar-title>
         <v-progress-circular
           v-if="!currentDandiset || loading"
           indeterminate

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -20,7 +20,11 @@
     </template>
     <template v-else>
       <v-toolbar class="grey darken-2 white--text">
-        <DandisetSearchField />
+        <v-row>
+          <v-col cols="12">
+            <DandisetSearchField />
+          </v-col>
+        </v-row>
       </v-toolbar>
       <v-container
         v-if="currentDandiset"


### PR DESCRIPTION
Closes #702 via the following changes:
- Remove the uninformative "Dandiset Dashboard" title
- Move the search bar to the left of the navbar
- Remove the open/close widget for the dandiset detail panel

I chose to simply remove the open/close control because the detail panel is unobtrusive and contains critical information about the dandiset. Until there's a positive need to hide it, I believe this is a better design solution in general.

@satra, if you could leave a review containing your feelings on whether/how well this solves the UX issues you raised, that would be great.

@jtomeck, please leave any design/Vuetify/CSS feedback you might have.

Thanks!