### PR TITLE
Add unsaved changes warning and undo functionality to meditor

### DIFF
--- a/src/utils/schema/editor.ts
+++ b/src/utils/schema/editor.ts
@@ -69,6 +69,18 @@ class EditorInterface {
     return this.model;
   }
 
+  setBasicModel(newModel: DandiModel) {
+    Object.entries(newModel).forEach(([key, value]) => {
+      Vue.set(this.basicModel.value, key, value);
+    });
+  }
+
+  setComplexModel(newModel: DandiModel) {
+    Object.entries(newModel).forEach(([key, value]) => {
+      Vue.set(this.complexModel, key, value);
+    });
+  }
+
   setComplexModelProp(propKey: string, value: DandiModel) {
     Vue.set(this.complexModel, propKey, value);
   }

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -128,15 +128,15 @@ export default class MeditorTransactionTracker {
     return this.transactions[this.transactionPointer].complex;
   }
 
-  areTransactionsAhead() {
+  areTransactionsAhead(): boolean {
     return this.transactionPointer < this.transactions.length - 1;
   }
 
-  areTransactionsBehind() {
+  areTransactionsBehind(): boolean {
     return this.transactionPointer > -1;
   }
 
-  isModified() {
+  isModified(): boolean {
     return this.transactionPointer > -1 || this.lostTransactions;
   }
 

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -1,0 +1,152 @@
+import { EditorInterface } from '@/utils/schema/editor';
+import { DandiModel } from '@/utils/schema/types';
+import { cloneDeep, isEqual } from 'lodash';
+
+interface MeditorTransaction {
+  field: string,
+  newValue: any,
+  oldValue: any,
+  complex: boolean, // true if this transaction is on the complex model, false if on basic
+}
+
+// maximum number of transactions that can be pushed
+// to the stack before they start to be discarded
+const MAX_TRANSACTION_STACK_SIZE = 500;
+
+class MeditorTransactionTracker {
+  private transactions: MeditorTransaction[];
+
+  // a "pointer" to the current transaction, i.e. the index
+  // of the current transaction in the transactions array
+  private transactionPointer: number;
+
+  // true if transactions are discarded due to reaching the max stack size
+  private lostTransactions: boolean;
+
+  // a reference to the EditorInterface of the meditor
+  private editorInterface: EditorInterface;
+
+  // the current data
+  public currentBasicModel: DandiModel;
+  public currentComplexModel: DandiModel;
+
+  constructor(editorInterface: EditorInterface) {
+    this.transactions = [];
+    this.transactionPointer = -1;
+    this.lostTransactions = false;
+    this.currentBasicModel = cloneDeep(editorInterface.basicModel.value);
+    this.currentComplexModel = cloneDeep(editorInterface.complexModel);
+    this.editorInterface = editorInterface;
+  }
+
+  // record a new change to the metadata
+  add(newModel: DandiModel, complex: boolean) {
+    // if there's transactions ahead of this one (due to a previous undo), get rid of them
+    if (this.transactionPointer < this.transactions.length - 1) {
+      this.transactions.splice(
+        this.transactionPointer + 1,
+        this.transactions.length - (this.transactionPointer + 1),
+      );
+    }
+
+    const oldModel = complex ? this.currentComplexModel : this.currentBasicModel;
+
+    // figure out what changed and record it as a transaction
+    Object.keys(oldModel).forEach((propKey) => {
+      if (!isEqual(oldModel[propKey], newModel[propKey])) {
+        this.transactions.push({
+          field: propKey,
+          newValue: newModel[propKey],
+          oldValue: oldModel[propKey],
+          complex,
+        });
+        if (this.transactions.length === MAX_TRANSACTION_STACK_SIZE) {
+          // If the max stack size is reached, remove an element from the bottom of the stack.
+          // The transaction pointer should stay the same.
+          this.transactions.shift();
+          this.lostTransactions = true;
+        } else {
+          this.transactionPointer += 1;
+        }
+      }
+    });
+
+    if (complex) {
+      this.currentComplexModel = cloneDeep(newModel);
+    } else {
+      this.currentBasicModel = cloneDeep(newModel);
+    }
+  }
+
+  // undo a change. Returns true if the change was to a complex form, false if to a basic form.
+  undo(): boolean|null {
+    if (this.transactionPointer < 0) {
+      return null;
+    }
+
+    const currentModel = this.transactions[this.transactionPointer].complex
+      ? this.currentComplexModel : this.currentBasicModel;
+
+    currentModel[
+      this.transactions[this.transactionPointer].field
+    ] = this.transactions[this.transactionPointer].oldValue;
+
+    // make sure to apply the changes to the correct model
+    if (this.transactions[this.transactionPointer].complex) {
+      this.editorInterface.setComplexModel(currentModel);
+    } else {
+      this.editorInterface.setBasicModel(currentModel);
+    }
+
+    this.transactionPointer -= 1;
+
+    return this.transactions[this.transactionPointer + 1].complex;
+  }
+
+  // redo a change. Returns true if the change was to a complex form, false if to a basic form.
+  redo(): boolean|null {
+    if (this.transactionPointer === this.transactions.length - 1) {
+      return null;
+    }
+
+    this.transactionPointer += 1;
+
+    const currentModel = this.transactions[this.transactionPointer].complex
+      ? this.currentComplexModel : this.currentBasicModel;
+
+    currentModel[
+      this.transactions[this.transactionPointer].field
+    ] = this.transactions[this.transactionPointer].newValue;
+
+    // make sure to apply the changes to the correct model
+    if (this.transactions[this.transactionPointer].complex) {
+      this.editorInterface.setComplexModel(currentModel);
+    } else {
+      this.editorInterface.setBasicModel(currentModel);
+    }
+
+    return this.transactions[this.transactionPointer].complex;
+  }
+
+  areTransactionsAhead() {
+    return this.transactionPointer < this.transactions.length - 1;
+  }
+
+  areTransactionsBehind() {
+    return this.transactionPointer > -1;
+  }
+
+  isModified() {
+    return this.transactionPointer > -1 || this.lostTransactions;
+  }
+
+  reset() {
+    this.transactions = [];
+    this.transactionPointer = -1;
+    this.lostTransactions = false;
+  }
+}
+
+export {
+  MeditorTransactionTracker,
+};

--- a/src/utils/transactions.ts
+++ b/src/utils/transactions.ts
@@ -13,7 +13,7 @@ interface MeditorTransaction {
 // to the stack before they start to be discarded
 const MAX_TRANSACTION_STACK_SIZE = 500;
 
-class MeditorTransactionTracker {
+export default class MeditorTransactionTracker {
   private transactions: MeditorTransaction[];
 
   // a "pointer" to the current transaction, i.e. the index
@@ -146,7 +146,3 @@ class MeditorTransactionTracker {
     this.lostTransactions = false;
   }
 }
-
-export {
-  MeditorTransactionTracker,
-};

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -233,7 +233,7 @@ import '@koumoul/vjsf/lib/VJsf.css';
 import { publishRest } from '@/rest';
 import { DandiModel, isJSONSchema } from '@/utils/schema/types';
 import { EditorInterface } from '@/utils/schema/editor';
-import { MeditorTransactionTracker } from '@/utils/transactions';
+import MeditorTransactionTracker from '@/utils/transactions';
 
 function renderField(fieldSchema: JSONSchema7) {
   const { properties } = fieldSchema;

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -52,7 +52,7 @@
                   icon
                   color="secondary"
                   v-on="on"
-                  @click="closeEditor"
+                  @click="exitMeditor"
                 >
                   <v-icon>
                     mdi-arrow-left
@@ -65,17 +65,49 @@
               <template #activator="{ on }">
                 <v-btn
                   icon
-                  color="primary"
+                  :color="modified ? 'warning' : 'primary'"
                   :disabled="readonly"
                   v-on="on"
                   @click="save"
                 >
-                  <v-icon>
-                    mdi-content-save
-                  </v-icon>
+                  <v-icon
+                    v-text="modified ? 'mdi-content-save-alert' : 'mdi-content-save'"
+                  />
                 </v-btn>
               </template>
               <span>Save</span>
+            </v-tooltip>
+            <v-tooltip bottom>
+              <template #activator="{ on }">
+                <v-btn
+                  icon
+                  color="secondary"
+                  :disabled="disableUndo"
+                  v-on="on"
+                  @click="undoChange"
+                >
+                  <v-icon>
+                    mdi-undo
+                  </v-icon>
+                </v-btn>
+              </template>
+              <span>Undo (CTRL-Z)</span>
+            </v-tooltip>
+            <v-tooltip bottom>
+              <template #activator="{ on }">
+                <v-btn
+                  icon
+                  color="secondary"
+                  :disabled="disableRedo"
+                  v-on="on"
+                  @click="redoChange"
+                >
+                  <v-icon>
+                    mdi-redo
+                  </v-icon>
+                </v-btn>
+              </template>
+              <span>Redo (CTRL-Y)</span>
             </v-tooltip>
             <v-spacer />
             <v-tooltip bottom>
@@ -122,10 +154,12 @@
               v-model="complexModelValidation[propKey]"
             >
               <v-jsf
+                ref="complexRef"
                 :value="complexModel[propKey]"
                 :schema="complexSchema.properties[propKey]"
                 :options="CommonVJSFOptions"
                 @input="setComplexModelProp(propKey, $event)"
+                @change="complexFormListener"
               />
             </v-form>
           </v-card>
@@ -139,11 +173,46 @@
         v-model="basicModelValid"
       >
         <v-jsf
+          ref="basicRef"
           v-model="basicModel"
           :schema="basicSchema"
           :options="{...CommonVJSFOptions, hideReadOnly: true}"
+          @change="basicFormListener"
         />
       </v-form>
+    </v-row>
+    <v-row
+      v-if="exiting && modified"
+      justify="center"
+    >
+      <v-dialog
+        v-model="exiting"
+        max-width="290"
+      >
+        <v-card>
+          <v-card-title class="text-h5">
+            Warning
+          </v-card-title>
+          <v-card-text>You have unsaved changes. Would you still like to exit?</v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn
+              color="green darken-1"
+              text
+              @click="exiting = false"
+            >
+              No
+            </v-btn>
+            <v-btn
+              color="green darken-1"
+              text
+              @click="closeEditor"
+            >
+              Yes
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
     </v-row>
   </v-container>
 </template>
@@ -152,7 +221,7 @@
 import type { JSONSchema7 } from 'json-schema';
 
 import {
-  defineComponent, PropType, ref, computed,
+  defineComponent, PropType, ref, computed, nextTick,
 } from '@vue/composition-api';
 
 import jsYaml from 'js-yaml';
@@ -164,6 +233,7 @@ import '@koumoul/vjsf/lib/VJsf.css';
 import { publishRest } from '@/rest';
 import { DandiModel, isJSONSchema } from '@/utils/schema/types';
 import { EditorInterface } from '@/utils/schema/editor';
+import { MeditorTransactionTracker } from '@/utils/transactions';
 
 function renderField(fieldSchema: JSONSchema7) {
   const { properties } = fieldSchema;
@@ -236,6 +306,60 @@ export default defineComponent({
     const publishDandiset = computed(() => store.state.dandiset.publishDandiset);
     const id = computed(() => publishDandiset.value?.dandiset.identifier || null);
 
+    const basicRef: any = ref(null);
+    const complexRef: any = ref(null);
+
+    const TransactionTracker = new MeditorTransactionTracker(editorInterface);
+
+    const undoChange = () => {
+      // Undo the change and then trigger revalidation of the form. The return value of undo()
+      // indicates whether this was a basic or complex form change.
+      if (TransactionTracker.undo()) {
+        nextTick().then(() => complexRef.value.forEach((formRef: any) => formRef.validate()));
+      } else {
+        nextTick().then(() => basicRef.value.validate());
+      }
+    };
+
+    const redoChange = () => {
+      // Redo the change and then trigger revalidation of the form. The return value of redo()
+      // indicates whether this was a basic or complex form change.
+      if (TransactionTracker.redo()) {
+        nextTick().then(() => complexRef.value.forEach((formRef: any) => formRef.validate()));
+      } else {
+        nextTick().then(() => basicRef.value.validate());
+      }
+    };
+
+    document.onkeydown = (event) => {
+      if (!props.readonly && event.ctrlKey && event.code === 'KeyZ') {
+        undoChange();
+      } else if (!props.readonly && event.ctrlKey && event.code === 'KeyY') {
+        redoChange();
+      }
+    };
+
+    const disableUndo = computed(
+      () => props.readonly || !TransactionTracker.areTransactionsBehind(),
+    );
+    const disableRedo = computed(
+      () => props.readonly || !TransactionTracker.areTransactionsAhead(),
+    );
+
+    const basicFormListener = () => TransactionTracker.add(basicModel.value, false);
+    const complexFormListener = () => TransactionTracker.add(complexModel, true);
+
+    const modified = computed(() => TransactionTracker.isModified());
+
+    const exiting = ref(false);
+    const exitMeditor = () => {
+      if (modified.value) {
+        exiting.value = true;
+        return;
+      }
+      closeEditor();
+    };
+
     async function save() {
       const dandiset = editorInterface.getModel();
 
@@ -248,7 +372,7 @@ export default defineComponent({
           // wait 0.5 seconds to give the celery worker some time to finish validation
           setTimeout(async () => {
             await store.dispatch('dandiset/fetchPublishDandiset', { identifier: data.dandiset.identifier, version: data.version });
-            closeEditor();
+            TransactionTracker.reset();
           }, 500);
         }
       } catch (error) {
@@ -287,11 +411,15 @@ export default defineComponent({
       basicSchema,
       basicModel,
       basicModelValid,
+      basicRef,
+      basicFormListener,
 
       complexSchema,
       complexModel,
       complexModelValid,
       complexModelValidation,
+      complexRef,
+      complexFormListener,
 
       invalidPermissionSnackbar,
       renderField,
@@ -300,9 +428,20 @@ export default defineComponent({
       download,
       sectionButtonColor,
 
+      modified,
+      exiting,
+      exitMeditor,
+
+      undoChange,
+      redoChange,
+      disableUndo,
+      disableRedo,
+
       CommonVJSFOptions,
 
       setComplexModelProp,
+
+      TransactionTracker,
     };
   },
 });

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -91,7 +91,7 @@
                   </v-icon>
                 </v-btn>
               </template>
-              <span>Undo (CTRL-Z)</span>
+              <span>Undo</span>
             </v-tooltip>
             <v-tooltip bottom>
               <template #activator="{ on }">
@@ -107,7 +107,7 @@
                   </v-icon>
                 </v-btn>
               </template>
-              <span>Redo (CTRL-Y)</span>
+              <span>Redo</span>
             </v-tooltip>
             <v-spacer />
             <v-tooltip bottom>
@@ -328,14 +328,6 @@ export default defineComponent({
         nextTick().then(() => complexRef.value.forEach((formRef: any) => formRef.validate()));
       } else {
         nextTick().then(() => basicRef.value.validate());
-      }
-    };
-
-    document.onkeydown = (event) => {
-      if (!props.readonly && event.ctrlKey && event.code === 'KeyZ') {
-        undoChange();
-      } else if (!props.readonly && event.ctrlKey && event.code === 'KeyY') {
-        redoChange();
       }
     };
 

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -128,7 +128,7 @@
         </v-card>
       </v-col>
     </v-row>
-    <v-row>
+    <v-row v-if="!readonly">
       <v-subheader>Click a field below to edit it.</v-subheader>
     </v-row>
     <v-row class="px-2">


### PR DESCRIPTION
Closes #685.

Adds
* Unsaved changes popup when attempting to exit meditor without saving
* undo/redo functionality to meditor (can be used via buttons in the UI or CTRL-Z/CTRL-Y)

Undo/redo is implemented using a transaction stack with a pointer to the current transaction. 
The stack has a maximum size limit to prevent the browsers memory from exploding (see `MAX_TRANSACTION_STACK_SIZE` in `src/utils/transactions.ts`). When the stack size reaches its limit, the element at the bottom of the stack is discarded whenever a new transaction occurs.