### PR TITLE
fix: change ID and title layout to match style

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -1,11 +1,12 @@
 <template>
   <div>
+    <v-card class="pb-2">
     <v-row
       class="mx-2"
       align="center"
     >
       <v-col cols="auto">
-        ID: {{ meta.id }}
+        Dandiset ID: {{ meta.id }}
       </v-col>
     </v-row>
     <v-row class="mx-2 my-2">
@@ -13,7 +14,6 @@
         {{ meta.name }}
       </h1>
     </v-row>
-    <v-card class="pb-2">
       <v-row
         class="mx-2"
         align="center"

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -5,14 +5,16 @@
       class="mx-2"
       align="center"
     >
-      <v-col cols="auto">
+      <v-col>
         Dandiset ID: {{ meta.id }}
       </v-col>
     </v-row>
     <v-row class="mx-2 my-2">
-      <h1 class="font-weight-regular">
-        {{ meta.name }}
-      </h1>
+      <v-col>
+        <h1 class="font-weight-regular">
+          {{ meta.name }}
+        </h1>
+      </v-col>
     </v-row>
       <v-row
         class="mx-2"

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card class="pb-2">
     <v-row
-      class="mx-2"
+      class="mx-2 font-weight-regular"
       align="center"
     >
       <v-col>


### PR DESCRIPTION
This attempts to adjust the top of the dandiset details page to improve stylistic matching of the rest of the flow.

closes #705