### PR TITLE
Load complex schema's VJsf form lazily in meditor

### DIFF
--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -121,12 +121,14 @@
               :ref="`${propKey}-form`"
               v-model="complexModelValidation[propKey]"
             >
-              <v-jsf
-                :value="complexModel[propKey]"
-                :schema="complexSchema.properties[propKey]"
-                :options="CommonVJSFOptions"
-                @input="setComplexModelProp(propKey, $event)"
-              />
+              <v-lazy>
+                <v-jsf
+                  :value="complexModel[propKey]"
+                  :schema="complexSchema.properties[propKey]"
+                  :options="CommonVJSFOptions"
+                  @input="setComplexModelProp(propKey, $event)"
+                />
+              </v-lazy>
             </v-form>
           </v-card>
         </v-dialog>


### PR DESCRIPTION
This is a quick/temporary fix for the performance issues mentioned in #694. Since the slowdown is caused by the "complex schema" VJsf forms (i.e. any form that is opened as a pop up, such as "Dandiset Contributors", "Subject Matter", etc), this PR modifies these to be loaded only when the user clicks the appropriate button.

For example, [this dandiset](https://gui.dandiarchive.org/#/dandiset/000004) would load immediately when the Meditor is opened and will only lag when the "Dandiset Contributors" form is opened (see https://github.com/dandi/dandiarchive/issues/694#issuecomment-856860270)