### PR TITLE
update vjsf package to latest version

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "1.21.0",
+    "@koumoul/vjsf": "2.0.2",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/web/src/utils/schema/editor.ts
+++ b/web/src/utils/schema/editor.ts
@@ -2,7 +2,7 @@ import type { JSONSchema7 } from 'json-schema';
 
 import Vue from 'vue';
 import {
-  computed, reactive, ref, ComputedRef,
+  computed, reactive, ref, ComputedRef, Ref,
 } from '@vue/composition-api';
 import { cloneDeep } from 'lodash';
 
@@ -23,7 +23,7 @@ class EditorInterface {
   // Not guaranteed to be up to date, use getModel()
   private model: DandiModel;
 
-  basicModel: DandiModel;
+  basicModel: Ref<DandiModel>;
   complexModel: DandiModel;
 
   schema: JSONSchema7;
@@ -46,7 +46,7 @@ class EditorInterface {
     this.basicSchema = computeBasicSchema(this.schema);
     this.complexSchema = computeComplexSchema(this.schema);
 
-    this.basicModel = reactive(filterModelWithSchema(this.model, this.basicSchema));
+    this.basicModel = ref(filterModelWithSchema(this.model, this.basicSchema));
     this.complexModel = reactive(filterModelWithSchema(this.model, this.complexSchema));
 
     this.modelValid = computed(() => this.basicModelValid.value && this.complexModelValid.value);
@@ -60,7 +60,7 @@ class EditorInterface {
   }
 
   syncModel() {
-    writeSubModelToMaster(this.basicModel, this.basicSchema, this.model);
+    writeSubModelToMaster(this.basicModel.value, this.basicSchema, this.model);
     writeSubModelToMaster(this.complexModel, this.complexSchema, this.model);
   }
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1001,16 +1001,19 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-1.21.0.tgz#f281f967b296a9c8672ab9b04a7d03c3c55eae1f"
-  integrity sha512-Juq9QY1zuImkM4zInN3TuKwUC0Q79sZlZEcQM9ZMoHDdtzIu/Kk5927U/UGXv5MQSnnWkfTaTE5RePO1PYyR0g==
+"@koumoul/vjsf@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.2.tgz#37e0b1702e2297cdf425e3bc7b3af7e3e8e32356"
+  integrity sha512-+1Q3SP4oLjU0hO4gXqkc2Ki+pxdc8U8oN3b01GPFZLy7VEoVocd9NKGstQQpC7oTqyn/opG0w8Ggd1ulkfEfjg==
   dependencies:
     "@mdi/js" "^5.5.55"
     ajv "^6.12.0"
     debounce "^1.2.0"
+    fast-copy "^2.1.1"
+    fast-equals "^2.0.0"
     markdown-it "^8.4.2"
     match-all "^1.2.5"
+    object-hash "^2.1.1"
     property-expr "^1.5.1"
     vuedraggable "^2.24.3"
 
@@ -4305,10 +4308,20 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-copy@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.1.tgz#f5cbcf2df64215e59b8e43f0b2caabc19848083a"
+  integrity sha512-Qod3DdRgFZ8GUIM6ygeoZYpQ0QLW9cf/FS9KhhjlYggcSZXWAemAw8BOCO5LuYCrR3Uj3qXDVTUzOUwG8C7beQ==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-equals@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fast-equals/-/fast-equals-2.0.3.tgz#7039b0a039909f345a2ce53f6202a14e5f392efc"
+  integrity sha512-0EMw4TTUxsMDpDkCg0rXor2gsg+npVrMIHbEhvD0HZyIhUX6AktC/yasm+qKwfyswd06Qy95ZKk8p2crTo0iPA==
 
 fast-glob@^2.2.6:
   version "2.2.7"
@@ -6612,6 +6625,11 @@ object-hash@^1.1.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.1.tgz#fde452098a951cb145f039bb7d455449ddc126df"
   integrity sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==
+
+object-hash@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.9.0:
   version "1.10.3"


### PR DESCRIPTION
Updates VJSF to latest version which includes performance improvements; specifically, the meditor no longer freezes for several seconds when working with large array fields. Can be merged once schema 0.4.1 is ready in production.

Closes #694 
Closes #662 
Closes #646 
Closes #588