### PR TITLE
Configure Netlify to support staging in client

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,13 +5,13 @@ command = "yarn run build"
 
   [build.environment]
   VUE_APP_API_ROOT = "https://girder.dandiarchive.org/api/v1"
-  VUE_APP_OAUTH_API_ROOT = "https://api.dandiarchive.org/oauth/"
+  VUE_APP_OAUTH_API_ROOT = "https://api-staging.dandiarchive.org/oauth/"
   VUE_APP_OAUTH_CLIENT_ID = "Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl"
-  VUE_APP_PUBLISH_API_ROOT = "https://api.dandiarchive.org/api/"
+  VUE_APP_PUBLISH_API_ROOT = "https://api-staging.dandiarchive.org/api/"
   VUE_APP_SENTRY_DSN = "https://425b9a012300493d867e97785fae7b88@o308436.ingest.sentry.io/5196549"
 
-[context.staging]
+[context.production]
 
-  [context.staging.environment]
-  VUE_APP_OAUTH_API_ROOT = "https://api-staging.dandiarchive.org/oauth/"
-  VUE_APP_PUBLISH_API_ROOT = "https://api-staging.dandiarchive.org/api/"
+  [context.production.environment]
+  VUE_APP_OAUTH_API_ROOT = "https://api.dandiarchive.org/oauth/"
+  VUE_APP_PUBLISH_API_ROOT = "https://api.dandiarchive.org/api/"


### PR DESCRIPTION
In accordance with https://github.com/dandi/dandi-api/blob/master/doc/design/staging-1.md, `netlify.toml` is modified so every that branch deployment points to `api-staging.dandiarchive.org` *except* the deployment from the production branch (`master`). Any deployment from the production branch points to `https://api.dandiarchive.org/api/`.