### PR TITLE
Revert lazy loading of complex schema forms in Meditor

### DIFF
--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -121,14 +121,12 @@
               :ref="`${propKey}-form`"
               v-model="complexModelValidation[propKey]"
             >
-              <v-lazy>
-                <v-jsf
-                  :value="complexModel[propKey]"
-                  :schema="complexSchema.properties[propKey]"
-                  :options="CommonVJSFOptions"
-                  @input="setComplexModelProp(propKey, $event)"
-                />
-              </v-lazy>
+              <v-jsf
+                :value="complexModel[propKey]"
+                :schema="complexSchema.properties[propKey]"
+                :options="CommonVJSFOptions"
+                @input="setComplexModelProp(propKey, $event)"
+              />
             </v-form>
           </v-card>
         </v-dialog>


### PR DESCRIPTION
Reverts #729 and closes #737.

This will cause the slowdown to occur again until the migration to schema v0.4.1 is complete, but I think it's better to have slowdown then broken functionality.