### PR TITLE
Hide "Log In With Github" button when the page is embedded inside an iframe

### DIFF
--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -96,16 +96,6 @@
       </template>
       <template v-else>
         <v-btn
-          v-if="!DJANGO_API"
-          :to="{ name: 'userRegister' }"
-          class="mx-1"
-          color="primary"
-          outlined
-          rounded
-        >
-          Create Account
-        </v-btn>
-        <v-btn
           id="login"
           class="mx-1"
           color="primary"
@@ -123,7 +113,6 @@
 import { loggedIn, insideIFrame, publishRest } from '@/rest';
 import { dandiAboutUrl, dandiDocumentationUrl, dandiHelpUrl } from '@/utils/constants';
 import UserMenu from '@/components/AppBar/UserMenu.vue';
-import toggles from '@/featureToggle';
 
 export default {
   name: 'AppBar',
@@ -176,9 +165,7 @@ export default {
   },
   methods: {
     login() {
-      if (toggles.DJANGO_API) {
-        publishRest.login();
-      }
+      publishRest.login();
     },
   },
 };

--- a/web/src/components/AppBar/AppBar.vue
+++ b/web/src/components/AppBar/AppBar.vue
@@ -81,44 +81,46 @@
 
     <v-spacer />
 
-    <template v-if="loggedIn">
-      <v-btn
-        :to="{ name: 'createDandiset' }"
-        exact
-        class="mx-3"
-        color="primary"
-        rounded
-      >
-        New Dandiset
-      </v-btn>
-      <UserMenu />
-    </template>
-    <template v-else>
-      <v-btn
-        v-if="!DJANGO_API"
-        :to="{ name: 'userRegister' }"
-        class="mx-1"
-        color="primary"
-        outlined
-        rounded
-      >
-        Create Account
-      </v-btn>
-      <v-btn
-        id="login"
-        class="mx-1"
-        color="primary"
-        rounded
-        @click="login"
-      >
-        Log In with GitHub
-      </v-btn>
-    </template>
+    <div v-if="!insideIFrame">
+      <template v-if="loggedIn">
+        <v-btn
+          :to="{ name: 'createDandiset' }"
+          exact
+          class="mx-3"
+          color="primary"
+          rounded
+        >
+          New Dandiset
+        </v-btn>
+        <UserMenu />
+      </template>
+      <template v-else>
+        <v-btn
+          v-if="!DJANGO_API"
+          :to="{ name: 'userRegister' }"
+          class="mx-1"
+          color="primary"
+          outlined
+          rounded
+        >
+          Create Account
+        </v-btn>
+        <v-btn
+          id="login"
+          class="mx-1"
+          color="primary"
+          rounded
+          @click="login"
+        >
+          Log In with GitHub
+        </v-btn>
+      </template>
+    </div>
   </v-app-bar>
 </template>
 
 <script>
-import { loggedIn, publishRest } from '@/rest';
+import { loggedIn, insideIFrame, publishRest } from '@/rest';
 import { dandiAboutUrl, dandiDocumentationUrl, dandiHelpUrl } from '@/utils/constants';
 import UserMenu from '@/components/AppBar/UserMenu.vue';
 import toggles from '@/featureToggle';
@@ -166,6 +168,7 @@ export default {
   },
   computed: {
     loggedIn,
+    insideIFrame,
     returnObject() {
       const { name, query, params } = this.$route;
       return JSON.stringify({ name, query, params });

--- a/web/src/rest/index.ts
+++ b/web/src/rest/index.ts
@@ -4,10 +4,12 @@ import toggles from '@/featureToggle';
 
 const user = () => ((toggles.DJANGO_API) ? publishRest.user : girderRest.user);
 const loggedIn = () => !!user();
+const insideIFrame = () => window.self !== window.top;
 
 export {
   girderRest,
   publishRest,
   loggedIn,
   user,
+  insideIFrame,
 };


### PR DESCRIPTION
The `iframe` crashes if the login button is clicked when inside. This PR makes it so the `LOG IN WITH GITHUB` button is hidden when the page is embedded in an `iframe`. I also deleted any DJANGO_API feature toggle code that was related to the changes I made.

Closes #745 