### PR TITLE
Sort by "modified" by default instead of name

### DIFF
--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -78,16 +78,16 @@ const DANDISETS_PER_PAGE = 8;
 
 const sortingOptions = [
   {
-    name: 'Name',
-    djangoField: 'name',
+    name: 'Modified',
+    djangoField: 'modified',
   },
   {
     name: 'Identifier',
     djangoField: 'id',
   },
   {
-    name: 'Modified',
-    djangoField: 'modified',
+    name: 'Name',
+    djangoField: 'name',
   },
 ];
 


### PR DESCRIPTION
Makes `modified` the default way to sort dandisets instead of `name`.

Closes #734. 