### PR TITLE
Make publish validation error hover wrap lines

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -1,21 +1,21 @@
 <template>
   <div>
     <v-card class="pb-2">
-    <v-row
-      class="mx-2 font-weight-regular"
-      align="center"
-    >
-      <v-col>
-        Dandiset ID: {{ meta.id }}
-      </v-col>
-    </v-row>
-    <v-row class="mx-2 my-2">
-      <v-col>
-        <h1 class="font-weight-regular">
-          {{ meta.name }}
-        </h1>
-      </v-col>
-    </v-row>
+      <v-row
+        class="mx-2 font-weight-regular"
+        align="center"
+      >
+        <v-col>
+          Dandiset ID: {{ meta.id }}
+        </v-col>
+      </v-row>
+      <v-row class="mx-2 my-2">
+        <v-col>
+          <h1 class="font-weight-regular">
+            {{ meta.name }}
+          </h1>
+        </v-col>
+      </v-row>
       <v-row
         class="mx-2"
         align="center"
@@ -141,7 +141,10 @@
                 </v-btn>
               </div>
             </template>
-            {{ publishDisabledMessage }}
+            <p
+              :style="{ whiteSpace: 'pre-line' }"
+              v-text="publishDisabledMessage"
+            />
           </v-tooltip>
         </template>
       </v-row>


### PR DESCRIPTION
Makes validation errors that occur when hovering over the "Publish" button wrap to the next line when appropriate. Also remove all DJANGO_API feature toggle code from `DandisetMain.vue`.

Closes #762.