### PR TITLE
Asset.get_path frontend changes

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -173,9 +173,8 @@ const publishRest = new Vue({
       const { data } = await client.get('stats/');
       return data;
     },
-    assetDownloadURI(identifier: string, version: string, asset: Asset) {
-      const { asset_id } = asset;
-      return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${asset_id}/download/`;
+    assetDownloadURI(identifier: string, version: string, uuid: string) {
+      return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/download/`;
     },
     async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
       return client.delete(`${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/`);

--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -174,7 +174,7 @@ const publishRest = new Vue({
       return data;
     },
     assetDownloadURI(identifier: string, version: string, uuid: string) {
-      return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/download/`;
+      return `${publishApiRoot}assets/${uuid}/download/`;
     },
     async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
       return client.delete(`${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/`);

--- a/web/src/views/FileBrowserView/FileBrowser.vue
+++ b/web/src/views/FileBrowserView/FileBrowser.vue
@@ -41,7 +41,6 @@ export default {
   async created() {
     // Don't extract publishDandiset, for reactivity
     const { identifier, version } = this;
-
     if (!this.publishDandiset) {
       this.fetchPublishDandiset({ identifier, version });
     }

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -21,7 +21,7 @@
         <v-card-actions>
           <v-spacer />
           <v-btn
-            @click="dialogActive = false"
+            @click="itemToDelete = null"
           >
             Cancel
           </v-btn>
@@ -105,7 +105,7 @@
                 <v-btn
                   v-if="showDelete(item)"
                   icon
-                  @click="openDialog(item)"
+                  @click="itemToDelete = item;"
                 >
                   <v-icon color="error">
                     mdi-delete
@@ -155,7 +155,6 @@ export default {
       rootDirectory,
       location: rootDirectory,
       owners: [],
-      dialogActive: false,
       itemToDelete: null,
     };
   },
@@ -242,10 +241,6 @@ export default {
 
     showDelete(item) {
       return !item.folder && (this.isAdmin || this.isOwner);
-    },
-
-    openDialog(item) {
-      this.itemToDelete = item;
     },
 
     async deleteAsset(item) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -192,7 +192,7 @@ export default {
 
         if (data.files) {
           mapped = Object.keys(data.files).map(
-            (name) => ({ name, folder: false, ...data.files[name] }),
+            (name) => ({ ...data.files[name], name, folder: false }),
           );
           // set download links and uuids (needed for deleting) for files
           mapped.forEach((item) => {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -105,7 +105,7 @@
                 <v-btn
                   v-if="showDelete(item)"
                   icon
-                  @click="itemToDelete = item;"
+                  @click="itemToDelete = item"
                 >
                   <v-icon color="error">
                     mdi-delete

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -187,29 +187,15 @@ export default {
         this.owners = (await publishRest.owners(identifier)).data
           .map((x) => x.username);
 
-        // flatten the assetPaths object into an array:
-        let mapped = [];
-
-        if (data.folders) {
-          mapped = Object.keys(data.folders).map(
-            (name) => ({ name: `${name}/`, folder: true, ...data.folders[name] }),
-          );
-        }
-
-        if (data.files) {
-          mapped = mapped.concat(Object.keys(data.files).map(
-            (name) => ({ ...data.files[name], name, folder: false }),
-          ));
-        }
-
-        if (location !== rootDirectory && mapped.length) {
-          mapped = [
-            { name: parentDirectory, folder: true },
-            ...mapped,
-          ];
-        }
-
-        return mapped;
+        return [
+          ...location !== rootDirectory ? [{ name: parentDirectory, folder: true }] : [],
+          ...Object.keys(data.folders).map(
+            (key) => ({ ...data.folders[key], name: `${key}/`, folder: true }),
+          ),
+          ...Object.keys(data.files).map(
+            (key) => ({ ...data.files[key], name: key, folder: false }),
+          ),
+        ];
       },
       default: null,
     },

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -113,10 +113,10 @@
                 </v-btn>
               </v-list-item-action>
 
-              <v-list-item-action v-if="item.download_url">
+              <v-list-item-action v-if="item.asset_id">
                 <v-btn
                   icon
-                  :href="item.download_url"
+                  :href="downloadURI(item.asset_id)"
                 >
                   <v-icon color="primary">
                     mdi-download
@@ -237,6 +237,10 @@ export default {
       } else {
         this.location = `${this.location}${name}`;
       }
+    },
+
+    downloadURI(asset_id) {
+      return publishRest.assetDownloadURI(this.identifier, this.version, asset_id);
     },
 
     showDelete(item) {


### PR DESCRIPTION
Updates the file browser component to make use of the additional data returned from the `Asset.get_path` endpoint introduced in https://github.com/dandi/dandi-api/pull/312.

These changes eliminate the slowdown that occurs in the file browser mentioned in #600 (closes #600).

Blocked until https://github.com/dandi/dandi-api/pull/312 is merged, so I'll mark this as draft for now.