### PR TITLE
Remove `girderize` function

### DIFF
--- a/web/src/components/AppBar/UserMenu.vue
+++ b/web/src/components/AppBar/UserMenu.vue
@@ -46,13 +46,6 @@ export default {
     user,
     userInitials() {
       if (this.user) {
-        // TODO Girder uses camelCase. Delete after Girder is deprecated.
-        const { firstName, lastName } = this.user;
-        if (firstName && lastName) {
-          return (
-            firstName.charAt(0).toLocaleUpperCase() + lastName.charAt(0).toLocaleUpperCase()
-          );
-        }
         const { name } = this.user;
         if (name) {
           const name_parts = name.split(' ');

--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -9,12 +9,12 @@
       selectable
       :to="{
         name: 'dandisetLanding',
-        params: { identifier: item.meta.dandiset.identifier, origin }
+        params: { identifier: item.dandiset.identifier, origin }
       }"
     >
       <v-list-item-content>
         <v-list-item-title class="wrap-text text-h6 grey--text text--darken-3 pb-1">
-          {{ item.meta.dandiset.name }}
+          {{ item.name }}
         </v-list-item-title>
         <v-list-item-subtitle>
           <v-chip
@@ -35,11 +35,11 @@
           >
             <b>DRAFT</b>
           </v-chip>
-          DANDI:<b>{{ item.meta.dandiset.identifier }}</b>
+          DANDI:<b>{{ item.dandiset.identifier }}</b>
           ·
           Contact <b>{{ getDandisetContact(item) }}</b>
           ·
-          Updated on <b>{{ formatDate(item.updated) }}</b>
+          Updated on <b>{{ formatDate(item.dandiset.modified) }}</b>
           ·
           <template v-if="dandisetStats">
             <v-icon
@@ -56,7 +56,7 @@
             >
               mdi-database
             </v-icon>
-            {{ filesize(dandisetStats[i].bytes, { round: 1, base: 10, standard: 'iec' }) }}
+            {{ filesize(dandisetStats[i].size, { round: 1, base: 10, standard: 'iec' }) }}
           </template>
         </v-list-item-subtitle>
       </v-list-item-content>

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -8,7 +8,6 @@ export interface Dandiset {
   identifier: string,
   created: string,
   modified: string,
-  // TODO these versions are girderized, they should have type Version
   draft_version?: any,
   most_recent_published_version?: any,
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -8,8 +8,10 @@ export interface Dandiset {
   identifier: string,
   created: string,
   modified: string,
-  draft_version?: any,
-  most_recent_published_version?: any,
+  // eslint-disable-next-line no-use-before-define
+  draft_version?: Version,
+  // eslint-disable-next-line no-use-before-define
+  most_recent_published_version?: Version,
 }
 
 export interface Version {

--- a/web/src/utils/index.js
+++ b/web/src/utils/index.js
@@ -48,7 +48,7 @@ function copyToClipboard(text) {
 }
 
 function getDandisetContact(dandiset) {
-  if (dandiset.meta.dandiset.contributors) {
+  if (dandiset.meta?.dandiset.contributors) {
     const contact = dandiset.meta.dandiset.contributors.find((cont) => cont.roles && cont.roles.includes('ContactPerson'));
 
     if (!contact) return null;

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -34,7 +34,7 @@
 
     <v-row :class="`${rowClasses} px-2`">
       <span :class="labelClasses">Identifier</span>
-      <span :class="itemClasses">{{ currentDandiset.meta.dandiset.identifier }}</span>
+      <span :class="itemClasses">{{ currentDandiset.dandiset.identifier }}</span>
     </v-row>
 
     <template v-if="stats">
@@ -46,7 +46,7 @@
           <v-icon color="primary">
             mdi-file
           </v-icon>
-          {{ stats.items }}
+          {{ stats.asset_count }}
         </v-col>
         <v-col
           class="text--secondary mx-2 pa-0 py-1"
@@ -247,11 +247,11 @@ export default {
       return this.formatDateTime(this.currentDandiset.updated);
     },
     contactName() {
-      if (!this.currentDandiset || !this.currentDandiset.meta.dandiset.contributors) {
+      if (!this.currentDandiset || !this.currentDandiset.metadata.contributors) {
         return null;
       }
 
-      const contacts = this.currentDandiset.meta.dandiset.contributors.filter(
+      const contacts = this.currentDandiset.metadata.contributors.filter(
         (contributor) => contributor.roles.includes('ContactPerson'),
       );
 
@@ -284,7 +284,7 @@ export default {
       if (!stats) {
         return undefined;
       }
-      return filesize(stats.bytes, { round: 1, base: 10, standard: 'iec' });
+      return filesize(stats.size, { round: 1, base: 10, standard: 'iec' });
     },
     versions() {
       return this.publishedVersions || [];
@@ -300,8 +300,8 @@ export default {
   },
   asyncComputed: {
     async stats() {
-      const { items, bytes } = this.currentDandiset;
-      return { items, bytes };
+      const { asset_count, size } = this.currentDandiset;
+      return { asset_count, size };
     },
   },
   watch: {

--- a/web/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/web/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -96,10 +96,7 @@ export default {
     },
     meta() {
       if (this.publishDandiset) {
-        return {
-          name: this.publishDandiset.name,
-          ...this.publishDandiset.meta.dandiset,
-        };
+        return this.publishDandiset.metadata;
       }
 
       return {};
@@ -116,7 +113,7 @@ export default {
     userCanModifyDandiset: {
       async get() {
         // published versions are never editable
-        if (this.publishDandiset.meta.dandiset.version !== 'draft') {
+        if (this.publishDandiset.metadata.version !== 'draft') {
           return false;
         }
 
@@ -128,7 +125,7 @@ export default {
           return true;
         }
 
-        const { identifier } = this.publishDandiset.meta.dandiset;
+        const { identifier } = this.publishDandiset.dandiset;
         const { data: owners } = await publishRest.owners(identifier);
         const userExists = owners.find((owner) => owner.username === this.user.username);
         return !!userExists;

--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -317,7 +317,7 @@ export default {
         return 'You do not have permission to edit this dandiset.';
       }
       if (this.publishDandiset.status === 'Invalid') {
-        return this.publishDandiset.validationError;
+        return this.publishDandiset.validation_error;
       }
       if (this.publishDandiset.status === 'Pending') {
         return 'This dandiset has not yet been validated.';
@@ -336,7 +336,7 @@ export default {
     },
     fileBrowserLink() {
       const { version } = this;
-      const { identifier } = this.publishDandiset.meta.dandiset;
+      const { identifier } = this.publishDandiset.dandiset;
       // TODO: this probably does not work correctly yet
       return {
         name: 'fileBrowser',
@@ -347,7 +347,7 @@ export default {
       };
     },
     permalink() {
-      return `${dandiUrl}/dandiset/${this.meta.identifier}/${this.version}`;
+      return `${dandiUrl}/dandiset/${this.publishDandiset.dandiset.identifier}/${this.version}`;
     },
     extraFields() {
       const { meta, mainFields } = this;
@@ -373,8 +373,7 @@ export default {
   },
   methods: {
     async publish() {
-      // TODO ungirderize
-      const version = await publishRest.publish(this.publishDandiset.meta.dandiset.identifier);
+      const version = await publishRest.publish(this.publishDandiset.dandiset.identifier);
       // re-initialize the dataset to load the newly published version
       await this.$store.dispatch('dandiset/initializeDandisets', { identifier: version.dandiset.identifier, version: version.version });
     },

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -84,17 +84,8 @@ import { publishRest, user } from '@/rest';
 import { mapState, mapMutations } from 'vuex';
 import _ from 'lodash';
 
-const girderize = (users) => users.map(
-  ({ username, name }) => ({
-    id: username,
-    login: username,
-    username,
-    name,
-  }),
-);
-
 // Includes a field `result` on each user which is the value displayed in the UI
-const appendResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.login})` : u.login }));
+const appendResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.username})` : u.username }));
 
 export default {
   name: 'DandisetOwnersDialog',
@@ -109,7 +100,7 @@ export default {
       search: null,
       loadingUsers: false,
       selection: null,
-      newOwners: appendResult(girderize(this.owners)),
+      newOwners: appendResult(this.owners),
       items: [],
       throttledUpdate: _.debounce(this.updateItems, 200),
     };
@@ -130,7 +121,7 @@ export default {
 
       this.loadingUsers = true;
       const users = await publishRest.searchUsers(this.search);
-      this.items = appendResult(girderize(users));
+      this.items = appendResult(users);
       this.loadingUsers = false;
     },
     removeOwner(index) {

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -131,7 +131,7 @@ export default {
       this.$emit('close');
     },
     async save() {
-      const { identifier } = this.publishDandiset.meta.dandiset;
+      const { identifier } = this.publishDandiset.metadata;
       const { data } = await publishRest.setOwners(identifier, this.newOwners);
       this.setOwners(data);
       this.close();

--- a/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/web/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -131,7 +131,7 @@ export default {
       this.$emit('close');
     },
     async save() {
-      const { identifier } = this.publishDandiset.metadata;
+      const { identifier } = this.publishDandiset.dandiset;
       const { data } = await publishRest.setOwners(identifier, this.newOwners);
       this.setOwners(data);
       this.close();

--- a/web/src/views/DandisetLandingView/DownloadDialog.vue
+++ b/web/src/views/DandisetLandingView/DownloadDialog.vue
@@ -166,7 +166,7 @@ export default {
         .map((version, index) => ({ version: version.version, index }));
     },
     identifier() {
-      return this.publishDandiset.meta.dandiset.identifier;
+      return this.publishDandiset.dandiset.identifier;
     },
     ...mapState('dandiset', {
       publishDandiset: (state) => state.publishDandiset,

--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -162,7 +162,6 @@ import '@koumoul/vjsf/lib/deps/third-party';
 import '@koumoul/vjsf/lib/VJsf.css';
 
 import { publishRest } from '@/rest';
-import { girderize } from '@/rest/publish';
 import { DandiModel, isJSONSchema } from '@/utils/schema/types';
 import { EditorInterface } from '@/utils/schema/editor';
 
@@ -234,10 +233,10 @@ export default defineComponent({
       disableAll: props.readonly,
     }));
     const publishDandiset = computed(() => store.state.dandiset.publishDandiset);
-    const id = computed(() => publishDandiset.value?.meta.dandiset.identifier || null);
+    const id = computed(() => publishDandiset.value?.dandiset.identifier || null);
     function setDandiset(payload: any) {
       // TODO: Replace once direct-vuex is added
-      store.commit('dandiset/setPublishDandiset', girderize(payload));
+      store.commit('dandiset/setPublishDandiset', payload);
     }
 
     async function save() {


### PR DESCRIPTION
Removes the `girderize` function from the codebase and updates dependent code to directly use the Girder 4 dandiset format. 