### PR TITLE
Fix contact person display in UI

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -37,7 +37,7 @@
           </v-chip>
           DANDI:<b>{{ item.dandiset.identifier }}</b>
           ·
-          Contact <b>{{ getDandisetContact(item) }}</b>
+          Contact <b>{{ item.contact_person }}</b>
           ·
           Updated on <b>{{ formatDate(item.dandiset.modified) }}</b>
           ·
@@ -70,8 +70,6 @@ import {
 } from '@vue/composition-api';
 import moment from 'moment';
 import filesize from 'filesize';
-
-import { getDandisetContact } from '@/utils';
 
 type Dandiset = {};
 interface DandisetStats {
@@ -122,7 +120,6 @@ export default defineComponent({
 
       // Returned imports
       filesize,
-      getDandisetContact,
     };
   },
 });

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -137,9 +137,12 @@ export default defineComponent({
       djangoDandisetRequest.value = response.data;
     });
 
-    const dandisets = computed(() => djangoDandisetRequest.value?.results.map(
-      (dandiset) => dandiset.most_recent_published_version || dandiset.draft_version,
-    ));
+    // Unified Django + Girder
+
+    const dandisets = computed(() => djangoDandisetRequest.value?.results.map((dandiset) => ({
+      ...(dandiset.most_recent_published_version || dandiset.draft_version),
+      contact_person: dandiset.contact_person,
+    })));
 
     const pages = computed(() => {
       const totalDandisets: number = djangoDandisetRequest.value?.count || 0;

--- a/web/src/components/DandisetsPage.vue
+++ b/web/src/components/DandisetsPage.vue
@@ -137,8 +137,6 @@ export default defineComponent({
       djangoDandisetRequest.value = response.data;
     });
 
-    // Unified Django + Girder
-
     const dandisets = computed(() => djangoDandisetRequest.value?.results.map((dandiset) => ({
       ...(dandiset.most_recent_published_version || dandiset.draft_version),
       contact_person: dandiset.contact_person,

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -8,8 +8,10 @@ export interface Dandiset {
   identifier: string,
   created: string,
   modified: string,
-  draft_version?: any,
-  most_recent_published_version?: any,
+  // eslint-disable-next-line no-use-before-define
+  draft_version?: Version,
+  // eslint-disable-next-line no-use-before-define
+  most_recent_published_version?: Version,
   contact_person?: string,
 }
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -8,10 +8,9 @@ export interface Dandiset {
   identifier: string,
   created: string,
   modified: string,
-  // eslint-disable-next-line no-use-before-define
-  draft_version?: Version,
-  // eslint-disable-next-line no-use-before-define
-  most_recent_published_version?: Version,
+  draft_version?: any,
+  most_recent_published_version?: any,
+  contact_person?: string,
 }
 
 export interface Version {

--- a/web/src/utils/index.js
+++ b/web/src/utils/index.js
@@ -47,22 +47,10 @@ function copyToClipboard(text) {
   return false;
 }
 
-function getDandisetContact(dandiset) {
-  if (dandiset.meta?.dandiset.contributors) {
-    const contact = dandiset.meta.dandiset.contributors.find((cont) => cont.roles && cont.roles.includes('ContactPerson'));
-
-    if (!contact) return null;
-    return contact.name;
-  }
-
-  return null;
-}
-
 export {
   getLocationFromRoute,
   getPathFromLocation,
   getSelectedFromRoute,
   getPathFromSelected,
   copyToClipboard,
-  getDandisetContact,
 };

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -247,11 +247,7 @@ export default {
       return this.formatDateTime(this.currentDandiset.updated);
     },
     contactName() {
-      if (!this.currentDandiset) {
-        return null;
-      }
-
-      return this.currentDandiset.contact_person;
+      return this.currentDandiset?.contact_person;
     },
     currentDandiset() {
       return this.publishDandiset;

--- a/web/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/web/src/views/DandisetLandingView/DandisetDetails.vue
@@ -247,19 +247,11 @@ export default {
       return this.formatDateTime(this.currentDandiset.updated);
     },
     contactName() {
-      if (!this.currentDandiset || !this.currentDandiset.metadata.contributors) {
+      if (!this.currentDandiset) {
         return null;
       }
 
-      const contacts = this.currentDandiset.metadata.contributors.filter(
-        (contributor) => contributor.roles.includes('ContactPerson'),
-      );
-
-      if (contacts.length > 0) {
-        return contacts[0].name;
-      }
-
-      return null;
+      return this.currentDandiset.contact_person;
     },
     currentDandiset() {
       return this.publishDandiset;


### PR DESCRIPTION
I discovered this when I was working on refactoring the old Girder 3 code out of the frontend. Currently, the "Contact" display is broken in the dandiset listing page and dandiset landing page. 

Dandiset listing page screenshot:

![Screenshot from 2021-07-05 13-22-07](https://user-images.githubusercontent.com/37340715/124503819-4bb54000-dd94-11eb-9d54-6e0f9f8ca29b.png)

Note the `Contact` field on each dandiset is empty. 

This is happening because the UI is assuming an older schema when trying to infer the Contact Person; this PR fixes that. 

Blocked on server changes in https://github.com/dandi/dandi-api/pull/401.