### PR TITLE
Update VJSF to version 2.0.3

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "2.0.2",
+    "@koumoul/vjsf": "2.0.3",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "2.0.4",
+    "@koumoul/vjsf": "2.1.2",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "2.0.3",
+    "@koumoul/vjsf": "2.0.4",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/web/package.json
+++ b/web/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "2.1.2",
+    "@mvandenburgh/vjsf": "^2.1.4",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/web/src/types/vjsf.d.ts
+++ b/web/src/types/vjsf.d.ts
@@ -1,1 +1,1 @@
-declare module '@koumoul/vjsf/lib/VJsf';
+declare module '@mvandenburgh/vjsf/lib/VJsf';

--- a/web/src/views/DandisetLandingView/Meditor.vue
+++ b/web/src/views/DandisetLandingView/Meditor.vue
@@ -157,9 +157,9 @@ import {
 
 import jsYaml from 'js-yaml';
 
-import VJsf from '@koumoul/vjsf/lib/VJsf';
-import '@koumoul/vjsf/lib/deps/third-party';
-import '@koumoul/vjsf/lib/VJsf.css';
+import VJsf from '@mvandenburgh/vjsf/lib/VJsf';
+import '@mvandenburgh/vjsf/lib/deps/third-party';
+import '@mvandenburgh/vjsf/lib/VJsf.css';
 
 import { publishRest } from '@/rest';
 import { girderize } from '@/rest/publish';

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -3,7 +3,7 @@ const child_process = require('child_process');
 
 function getVersion() {
   try {
-    return child_process.execSync("git describe").toString();
+    return child_process.execSync('git describe').toString();
   } catch (err) {
     return process.env.COMMIT_REF;
   }
@@ -11,9 +11,9 @@ function getVersion() {
 
 function getGitRevision() {
   try {
-    return child_process.execSync("git rev-parse HEAD").toString();
+    return child_process.execSync('git rev-parse HEAD').toString();
   } catch (err) {
-    return "";
+    return '';
   }
 }
 
@@ -24,7 +24,7 @@ module.exports = {
   lintOnSave: false,
   transpileDependencies: [
     'vuetify',
-    '@koumoul/vjsf',
+    '@mvandenburgh/vjsf',
     '@girder/oauth-client',
   ],
   devServer: {

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1001,10 +1001,10 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@2.0.3":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.3.tgz#499c1e80513269b32bbf5836ebf393126242897e"
-  integrity sha512-JuQ+WBDDUuTudk2vqtsCt7CBRGVgd6wg+TvTjozo4E9irvKSK+HquAYqUTvYVJN+yJ4K2DaC/x8fagTOgR2EYQ==
+"@koumoul/vjsf@2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.4.tgz#c6ab31391d784f978b3938a1659942f2ac8e3551"
+  integrity sha512-SNlTad486lPr3o5zsI5XX2KnBWMASxeEGQ+OYLd0UL1/b7AiB1ZJD0Od5L5gI6GfuuCMafUWkWePq3J5Sdqndw==
   dependencies:
     "@mdi/js" "^5.5.55"
     ajv "^6.12.0"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1001,10 +1001,10 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.2.tgz#37e0b1702e2297cdf425e3bc7b3af7e3e8e32356"
-  integrity sha512-+1Q3SP4oLjU0hO4gXqkc2Ki+pxdc8U8oN3b01GPFZLy7VEoVocd9NKGstQQpC7oTqyn/opG0w8Ggd1ulkfEfjg==
+"@koumoul/vjsf@2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.3.tgz#499c1e80513269b32bbf5836ebf393126242897e"
+  integrity sha512-JuQ+WBDDUuTudk2vqtsCt7CBRGVgd6wg+TvTjozo4E9irvKSK+HquAYqUTvYVJN+yJ4K2DaC/x8fagTOgR2EYQ==
   dependencies:
     "@mdi/js" "^5.5.55"
     ajv "^6.12.0"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1001,10 +1001,10 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.4.tgz#c6ab31391d784f978b3938a1659942f2ac8e3551"
-  integrity sha512-SNlTad486lPr3o5zsI5XX2KnBWMASxeEGQ+OYLd0UL1/b7AiB1ZJD0Od5L5gI6GfuuCMafUWkWePq3J5Sdqndw==
+"@koumoul/vjsf@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.1.2.tgz#4755bae6a9b6e2e6178e0b1c47da65d2009caa29"
+  integrity sha512-pz2wY/Wo5zzQ77DtM87S/rfAd1EsfZr7zIKrtvnEZm1qXO8awbp4RpUI89DFGyYyQcGshBsRgkIEC/piUPtdsA==
   dependencies:
     "@mdi/js" "^5.5.55"
     ajv "^6.12.0"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1001,22 +1001,6 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.1.2.tgz#4755bae6a9b6e2e6178e0b1c47da65d2009caa29"
-  integrity sha512-pz2wY/Wo5zzQ77DtM87S/rfAd1EsfZr7zIKrtvnEZm1qXO8awbp4RpUI89DFGyYyQcGshBsRgkIEC/piUPtdsA==
-  dependencies:
-    "@mdi/js" "^5.5.55"
-    ajv "^6.12.0"
-    debounce "^1.2.0"
-    fast-copy "^2.1.1"
-    fast-equals "^2.0.0"
-    markdown-it "^8.4.2"
-    match-all "^1.2.5"
-    object-hash "^2.1.1"
-    property-expr "^1.5.1"
-    vuedraggable "^2.24.3"
-
 "@mdi/font@^5.3.45":
   version "5.9.55"
   resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
@@ -1034,6 +1018,22 @@
   dependencies:
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
+
+"@mvandenburgh/vjsf@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@mvandenburgh/vjsf/-/vjsf-2.1.4.tgz#26d7f7f1c9a0ad6569855984b73e2c3bcfa9ee67"
+  integrity sha512-bOYAIX9IuLP0rriXSD6pDdm49on0VVDYB/BMIo163zq9K92h0mnumuOiywnitZqWUWI4ZqhGuGCn8x1upv3MDg==
+  dependencies:
+    "@mdi/js" "^5.5.55"
+    ajv "^6.12.0"
+    debounce "^1.2.0"
+    fast-copy "^2.1.1"
+    fast-equals "^2.0.0"
+    markdown-it "^8.4.2"
+    match-all "^1.2.5"
+    object-hash "^2.1.1"
+    property-expr "^1.5.1"
+    vuedraggable "^2.24.3"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
Updates VJSF to latest version, 2.0.3. 

Just opening this PR so I can test the new VJSF version with the netlify branch preview. 