### PR TITLE
Staging: Remove VUE_APP_API_ROOT env var

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,6 @@ publish = "dist"
 command = "yarn run build"
 
   [build.environment]
-  VUE_APP_API_ROOT = "https://girder.dandiarchive.org/api/v1"
   VUE_APP_OAUTH_API_ROOT = "https://api-staging.dandiarchive.org/oauth/"
   VUE_APP_OAUTH_CLIENT_ID = "Dk0zosgt1GAAKfN8LT4STJmLJXwMDPbYWYzfNtAl"
   VUE_APP_PUBLISH_API_ROOT = "https://api-staging.dandiarchive.org/api/"


### PR DESCRIPTION
The girder refactor removed this environment variable from `netlify.toml` so there's a merge conflict w/ the auto-rebasing that occurs in https://github.com/dandi/dandiarchive/blob/master/.github/workflows/sync-staging.yml.