### PR TITLE
Validation error UX improvements 

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -5,10 +5,32 @@ const dandiHelpUrl = 'https://github.com/dandi/helpdesk/issues/new/choose';
 
 const draftVersion = 'draft';
 
+const VALIDATION_ICONS = {
+  // version metadata
+  // https://github.com/dandi/schema/blob/master/releases/0.4.4/dandiset.json#L231
+  name: 'mdi-note',
+  description: 'mdi-text',
+  contributor: 'mdi-account-multiple',
+  license: 'mdi-gavel',
+  assetsSummary: 'mdi-file-multiple',
+
+  // asset metadata
+  // https://github.com/dandi/schema/blob/master/releases/0.4.4/asset.json#L312
+  contentSize: 'mdi-table-of-contents',
+  encodingFormat: 'mdi-code-json',
+  digest: 'mdi-barcode',
+  path: 'mdi-folder-multiple',
+  identifier: 'mdi-identifier',
+
+  // icon to use when one isn't found
+  DEFAULT: 'mdi-alert',
+};
+
 export {
   dandiUrl,
   dandiAboutUrl,
   dandiDocumentationUrl,
   draftVersion,
   dandiHelpUrl,
+  VALIDATION_ICONS,
 };


### PR DESCRIPTION
Start implementing UX improvements for publish validation errors on the DLP based on the mockups in #735.

This requires some breaking server changes so I want to get this watered-down version merged first and then open another PR to finish implementing Jared's full design from #735.

Requires https://github.com/dandi/dandi-api/pull/417 to be merged first.

![Screenshot from 2021-07-19 13-18-42](https://user-images.githubusercontent.com/37340715/126200643-0392b064-aab7-421e-a220-30a066e0bd37.png)
![Screenshot from 2021-07-19 13-18-59](https://user-images.githubusercontent.com/37340715/126200633-b23ec10c-43bc-42c2-bfd5-28b21bea7f74.png)
![Screenshot from 2021-07-19 13-18-51](https://user-images.githubusercontent.com/37340715/126200641-918ab799-2f38-4cf2-ab3e-ab04aa3b1aa1.png)


