### PR TITLE
Disable publish button when there are no changes

### DIFF
--- a/web/src/views/DandisetLandingView/DandisetMain.vue
+++ b/web/src/views/DandisetLandingView/DandisetMain.vue
@@ -327,6 +327,9 @@ export default {
       if (this.publishDandiset.status === 'Validating') {
         return 'Currently validating this dandiset.';
       }
+      if (this.publishDandiset.status === 'Published') {
+        return 'No changes since last publish.';
+      }
 
       return null;
     },


### PR DESCRIPTION
When dandiset status is `Published`, the publish button was still enabled, even though the publish request would fail (as of https://github.com/dandi/dandi-api/pull/419).

Fix that with a useful error message.