### PR TITLE
Display asset filesize + link to asset metadata

### DIFF
--- a/web/src/rest/publish.ts
+++ b/web/src/rest/publish.ts
@@ -176,6 +176,9 @@ const publishRest = new Vue({
     assetDownloadURI(identifier: string, version: string, uuid: string) {
       return `${publishApiRoot}assets/${uuid}/download/`;
     },
+    assetMetadataURI(identifier: string, version: string, uuid: string) {
+      return `${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}`;
+    },
     async deleteAsset(identifier: string, version: string, uuid: string): Promise<AxiosResponse> {
       return client.delete(`${publishApiRoot}dandisets/${identifier}/versions/${version}/assets/${uuid}/`);
     },

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -126,6 +126,18 @@
                   </v-icon>
                 </v-btn>
               </v-list-item-action>
+
+              <v-list-item-action v-if="item.asset_id">
+                <v-btn
+                  icon
+                  :href="assetMetadataURI(item.asset_id)"
+                >
+                  <v-icon color="primary">
+                    mdi-information
+                  </v-icon>
+                </v-btn>
+              </v-list-item-action>
+
               <v-list-item-action
                 v-if="item.size"
                 class="justify-end"
@@ -252,6 +264,10 @@ export default {
 
     downloadURI(asset_id) {
       return publishRest.assetDownloadURI(this.identifier, this.version, asset_id);
+    },
+
+    assetMetadataURI(asset_id) {
+      return publishRest.assetMetadataURI(this.identifier, this.version, asset_id);
     },
 
     fileSize(item) {

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -131,6 +131,8 @@
                 <v-btn
                   icon
                   :href="assetMetadataURI(item.asset_id)"
+                  target="_blank"
+                  rel="noopener"
                 >
                   <v-icon color="primary">
                     mdi-information

--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -74,6 +74,9 @@
                 </router-link>
               </template>
             </template>
+            <span class="ml-auto">
+              <b>Size</b>
+            </span>
           </v-card-title>
           <v-progress-linear
             v-if="$asyncComputed.items.updating"
@@ -123,6 +126,13 @@
                   </v-icon>
                 </v-btn>
               </v-list-item-action>
+              <v-list-item-action
+                v-if="item.size"
+                class="justify-end"
+                :style="{width: '4em'}"
+              >
+                {{ fileSize(item) }}
+              </v-list-item-action>
             </v-list-item>
           </v-list>
         </v-card>
@@ -133,6 +143,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import filesize from 'filesize';
 import { publishRest } from '@/rest';
 
 const parentDirectory = '..';
@@ -241,6 +252,10 @@ export default {
 
     downloadURI(asset_id) {
       return publishRest.assetDownloadURI(this.identifier, this.version, asset_id);
+    },
+
+    fileSize(item) {
+      return filesize(item.size, { round: 1, base: 10, standard: 'iec' });
     },
 
     showDelete(item) {


### PR DESCRIPTION
Display asset filesize and link to asset metadata in the file browser.