### PR TITLE
Fix incorrect "Updated On" display in list view

### DIFF
--- a/web/src/components/DandisetList.vue
+++ b/web/src/components/DandisetList.vue
@@ -39,7 +39,7 @@
           ·
           Contact <b>{{ item.contact_person }}</b>
           ·
-          Updated on <b>{{ formatDate(item.dandiset.modified) }}</b>
+          Updated on <b>{{ formatDate(item.modified) }}</b>
           ·
           <template v-if="dandisetStats">
             <v-icon


### PR DESCRIPTION
![Screenshot from 2021-07-20 10-49-07](https://user-images.githubusercontent.com/37340715/126345183-01f342b6-5050-4217-8f73-a02c0fcb1c52.png)

Note the "Updated on" fields despite sorting the dandisets by most recently modified.

The web GUI is using the `modified` field of the `Dandiset` when it should be using the `modified` field of the `Version`.