### PR TITLE
Prevent file sizes from wrapping around

### DIFF
--- a/web/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/web/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -143,7 +143,7 @@
               <v-list-item-action
                 v-if="item.size"
                 class="justify-end"
-                :style="{width: '4em'}"
+                :style="{width: '4.5em'}"
               >
                 {{ fileSize(item) }}
               </v-list-item-action>


### PR DESCRIPTION
Closes #802. The max length for a file size string is 8 (for ex, `234.5 GB`) so this should prevent any sizes from wrapping to the next line.