### PR TITLE
Use VJSF fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@koumoul/vjsf": "2.0.2",
+    "@mvandenburgh/vjsf": "^2.1.3-fork1",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/src/types/vjsf.d.ts
+++ b/src/types/vjsf.d.ts
@@ -1,1 +1,1 @@
-declare module '@koumoul/vjsf/lib/VJsf';
+declare module '@mvandenburgh/vjsf/lib/VJsf';

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -157,9 +157,9 @@ import {
 
 import jsYaml from 'js-yaml';
 
-import VJsf from '@koumoul/vjsf/lib/VJsf';
-import '@koumoul/vjsf/lib/deps/third-party';
-import '@koumoul/vjsf/lib/VJsf.css';
+import VJsf from '@mvandenburgh/vjsf/lib/VJsf';
+import '@mvandenburgh/vjsf/lib/deps/third-party';
+import '@mvandenburgh/vjsf/lib/VJsf.css';
 
 import { publishRest } from '@/rest';
 import { DandiModel, isJSONSchema } from '@/utils/schema/types';

--- a/vue.config.js
+++ b/vue.config.js
@@ -28,7 +28,7 @@ module.exports = {
   lintOnSave: false,
   transpileDependencies: [
     'vuetify',
-    '@koumoul/vjsf',
+    '@mvandenburgh/vjsf',
     '@girder/oauth-client',
   ],
   devServer: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,22 +1001,6 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@koumoul/vjsf@2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.0.2.tgz#37e0b1702e2297cdf425e3bc7b3af7e3e8e32356"
-  integrity sha512-+1Q3SP4oLjU0hO4gXqkc2Ki+pxdc8U8oN3b01GPFZLy7VEoVocd9NKGstQQpC7oTqyn/opG0w8Ggd1ulkfEfjg==
-  dependencies:
-    "@mdi/js" "^5.5.55"
-    ajv "^6.12.0"
-    debounce "^1.2.0"
-    fast-copy "^2.1.1"
-    fast-equals "^2.0.0"
-    markdown-it "^8.4.2"
-    match-all "^1.2.5"
-    object-hash "^2.1.1"
-    property-expr "^1.5.1"
-    vuedraggable "^2.24.3"
-
 "@mdi/font@^5.3.45":
   version "5.9.55"
   resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
@@ -1034,6 +1018,22 @@
   dependencies:
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
+
+"@mvandenburgh/vjsf@^2.1.3-fork1":
+  version "2.1.3-fork1"
+  resolved "https://registry.yarnpkg.com/@mvandenburgh/vjsf/-/vjsf-2.1.3-fork1.tgz#a6fd6205de0b77e14ba9fa83a73d2b20d18f6706"
+  integrity sha512-A4WVzvQf3GfJCE93rORjqLoRajgSUaN6mh+0dxrUG1oAR8IIpv3fLRqURC2l889lioTmSrUL7TaHYLl8kJ6+FQ==
+  dependencies:
+    "@mdi/js" "^5.5.55"
+    ajv "^6.12.0"
+    debounce "^1.2.0"
+    fast-copy "^2.1.1"
+    fast-equals "^2.0.0"
+    markdown-it "^8.4.2"
+    match-all "^1.2.5"
+    object-hash "^2.1.1"
+    property-expr "^1.5.1"
+    vuedraggable "^2.24.3"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
~~Upgrades VJSF to version 2.1.3.~~

Update 7/30: Switches to our [custom fork of VJSF](https://www.npmjs.com/package/@mvandenburgh/vjsf/v/2.1.3-fork1) that has improved meditor loading speeds. 