### PR TITLE
Fix console error on DLP

### DIFF
--- a/src/views/DandisetLandingView/DandisetLandingView.vue
+++ b/src/views/DandisetLandingView/DandisetLandingView.vue
@@ -113,7 +113,7 @@ export default {
     userCanModifyDandiset: {
       async get() {
         // published versions are never editable
-        if (this.publishDandiset.metadata.version !== 'draft') {
+        if (this.publishDandiset?.metadata.version !== 'draft') {
           return false;
         }
 


### PR DESCRIPTION
Closes #772. The console error is happening because `this.publishDandiset.metadata` is being accessed when `this.publishDandiset` is `null`. Fix it by checking if `this.publishDandiset` is null before attempting to access it.