### PR TITLE
Add notice about cookie usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "vue": "^2.6.11",
+    "vue-cookie-law": "^1.13.3",
     "vue-gtag": "^1.16.1",
     "vue-json-pretty": "^1.8.0",
     "vue-router": "^3.5.1",

--- a/src/components/DandiFooter.vue
+++ b/src/components/DandiFooter.vue
@@ -2,8 +2,11 @@
 import { copyToClipboard } from '@/utils';
 import { dandiAboutUrl } from '@/utils/constants';
 
+import CookieLaw from 'vue-cookie-law';
+
 export default {
   name: 'DandiFooter',
+  components: { CookieLaw },
   data: () => ({
     copied: false,
     dandiAboutUrl,
@@ -34,6 +37,11 @@ export default {
 <template>
   <v-footer class="text-body-2">
     <v-container>
+      <cookie-law theme="blood-orange">
+        <div slot="message">
+          We use cookies to ensure you get the best experience on DANDI.
+        </div>
+      </cookie-law>
       <v-row>
         <v-col offset="2">
           &copy; 2021 DANDI<br>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8823,6 +8823,11 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-cookie@^2.1.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/tiny-cookie/-/tiny-cookie-2.3.2.tgz#3b5fb4e0888cfa0b4728d5f6b7be3d3a88e6a5f0"
+  integrity sha512-qbymkVh+6+Gc/c9sqnvbG+dOHH6bschjphK3SHgIfT6h/t+63GBL37JXNoXEc6u/+BcwU6XmaWUuf19ouLVtPg==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9288,6 +9293,13 @@ vue-cli-plugin-vuetify@^2.4.0:
     null-loader "^3.0.0"
     semver "^7.1.2"
     shelljs "^0.8.3"
+
+vue-cookie-law@^1.13.3:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/vue-cookie-law/-/vue-cookie-law-1.13.3.tgz#c4fc5d9dd66772d4043c4f140790a0e502caabbc"
+  integrity sha512-n5ef5/dAB4cyUz6OaolYZEeyfV/fcsVU/RCTT/aHXcyjNbXf7EU2TgaOlMwu+cTOjdn5tBJKyKP6lr6IOUf9bg==
+  dependencies:
+    tiny-cookie "^2.1.1"
 
 vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.6.0:
   version "7.6.0"


### PR DESCRIPTION
There was some discussion about adding a notice about cookies to comply with the GDPR. This PR adds a banner to the bottom of the webpage that indicates cookies are being used when a user navigates to the archive for the first time -  not sure if that is sufficient for compliance.