### PR TITLE
Upgrade vjsf to latest forked version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@mvandenburgh/vjsf": "^2.1.3-fork1",
+    "@mvandenburgh/vjsf": "^2.1.3-fork3",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -230,6 +230,7 @@ export default defineComponent({
 
     const CommonVJSFOptions = computed(() => ({
       initialValidation: 'all',
+      disablePrefilledArrays: true,
       disableAll: props.readonly,
     }));
     const publishDandiset = computed(() => store.state.dandiset.publishDandiset);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,10 +1019,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@mvandenburgh/vjsf@^2.1.3-fork1":
-  version "2.1.3-fork1"
-  resolved "https://registry.yarnpkg.com/@mvandenburgh/vjsf/-/vjsf-2.1.3-fork1.tgz#a6fd6205de0b77e14ba9fa83a73d2b20d18f6706"
-  integrity sha512-A4WVzvQf3GfJCE93rORjqLoRajgSUaN6mh+0dxrUG1oAR8IIpv3fLRqURC2l889lioTmSrUL7TaHYLl8kJ6+FQ==
+"@mvandenburgh/vjsf@^2.1.3-fork3":
+  version "2.1.3-fork3"
+  resolved "https://registry.yarnpkg.com/@mvandenburgh/vjsf/-/vjsf-2.1.3-fork3.tgz#681c4fd5bdf4efc79d1b714a661dd11c47f89844"
+  integrity sha512-33uNUQUTabHuP/8Rx+75STDS8q4TSygayWcgl8xQdlhL5/xnEzOMYu+pecWisuop98jgxFltGygC7RbeFoGq3A==
   dependencies:
     "@mdi/js" "^5.5.55"
     ajv "^6.12.0"


### PR DESCRIPTION
I updated our forked version of vjsf to incorporate the toggle-able prefilled array functionality that I opened a PR for upstream; this PR makes dandiarchive use that one instead.