### PR TITLE
Show correct last-modified time in dandiset detail panel

### DIFF
--- a/src/views/DandisetLandingView/DandisetDetails.vue
+++ b/src/views/DandisetLandingView/DandisetDetails.vue
@@ -26,8 +26,8 @@
       :class="rowClasses"
     >
       <v-icon>mdi-update</v-icon>
-      <span :class="labelClasses">Last updated</span>
-      <span :class="itemClasses">{{ lastUpdated }}</span>
+      <span :class="labelClasses">Last modified</span>
+      <span :class="itemClasses">{{ lastModified }}</span>
     </v-row>
 
     <v-divider class="my-2" />
@@ -243,8 +243,8 @@ export default {
     created() {
       return this.formatDateTime(this.currentDandiset.created);
     },
-    lastUpdated() {
-      return this.formatDateTime(this.currentDandiset.updated);
+    lastModified() {
+      return this.formatDateTime(this.currentDandiset.modified);
     },
     contactName() {
       return this.currentDandiset?.contact_person;


### PR DESCRIPTION
The non-existent `updated` property was previously being passed to
momentjs as the last modified date. Since that value was always
`undefined`, and momentjs returns the current date and time when called
without arguments (or with `undefined`, apparently), this explains why
the frontend was always showing the current time for the last modified
value.

Closes #825.