### PR TITLE
Re-fetch dandiset metadata after modifying w/ meditor

### DIFF
--- a/src/rest/publish.ts
+++ b/src/rest/publish.ts
@@ -145,7 +145,7 @@ const publishRest = new Vue({
     },
     async saveDandiset(
       identifier: string, version: string, metadata: any,
-    ): Promise<AxiosResponse<Dandiset>> {
+    ): Promise<AxiosResponse<Version>> {
       return client.put(`dandisets/${identifier}/versions/${version}/`, {
         name: metadata.name,
         metadata,

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -245,8 +245,11 @@ export default defineComponent({
         );
 
         if (status === 200) {
-          await store.dispatch('dandiset/fetchPublishDandiset', { identifier: data.dandiset.identifier, version: data.version });
-          closeEditor();
+          // wait 0.5 seconds to give the celery worker some time to finish validation
+          setTimeout(async () => {
+            await store.dispatch('dandiset/fetchPublishDandiset', { identifier: data.dandiset.identifier, version: data.version });
+            closeEditor();
+          }, 500);
         }
       } catch (error) {
         if (error.response.status === 403) {

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -235,10 +235,6 @@ export default defineComponent({
     }));
     const publishDandiset = computed(() => store.state.dandiset.publishDandiset);
     const id = computed(() => publishDandiset.value?.dandiset.identifier || null);
-    function setDandiset(payload: any) {
-      // TODO: Replace once direct-vuex is added
-      store.commit('dandiset/setPublishDandiset', payload);
-    }
 
     async function save() {
       const dandiset = editorInterface.getModel();
@@ -249,7 +245,7 @@ export default defineComponent({
         );
 
         if (status === 200) {
-          setDandiset(data);
+          await store.dispatch('dandiset/fetchPublishDandiset', { identifier: data.dandiset.identifier, version: data.version });
           closeEditor();
         }
       } catch (error) {


### PR DESCRIPTION
#827 is happening because the web client doesn't fetch the new version metadata from the server after clicking the save button in the meditor. Instead, it updates the UI using the "local copy" of the version metadata that the user has just edited; this approach is no longer feasible since we are now displaying validation errors in the UI. This PR fixes this by triggering an API request for fresh metadata when the user saves changes in the meditor.

Note that validation is an asynchronous process, so there isn't actually a guarantee that it will be complete by the time the user makes a request for fresh data. To solve this "correctly", a flag in the database that is set when a version's/asset's validation errors are "stale" could be implemented in a future PR.