### PR TITLE
Prevent crash if cookies are disabled

### DIFF
--- a/src/components/AppBar/AppBar.vue
+++ b/src/components/AppBar/AppBar.vue
@@ -95,22 +95,35 @@
         <UserMenu />
       </template>
       <template v-else>
-        <v-btn
-          id="login"
-          class="mx-1"
-          color="primary"
-          rounded
-          @click="login"
+        <v-tooltip
+          bottom
+          :disabled="cookiesEnabled"
         >
-          Log In with GitHub
-        </v-btn>
+          <template #activator="{ on }">
+            <div v-on="on">
+              <v-btn
+                id="login"
+                class="mx-1"
+                color="primary"
+                rounded
+                :disabled="!cookiesEnabled"
+                @click="login"
+              >
+                Log In with GitHub
+              </v-btn>
+            </div>
+          </template>
+          <span>Enable cookies to log in.</span>
+        </v-tooltip>
       </template>
     </div>
   </v-app-bar>
 </template>
 
 <script>
-import { loggedIn, insideIFrame, publishRest } from '@/rest';
+import {
+  cookiesEnabled, loggedIn, insideIFrame, publishRest,
+} from '@/rest';
 import { dandiAboutUrl, dandiDocumentationUrl, dandiHelpUrl } from '@/utils/constants';
 import UserMenu from '@/components/AppBar/UserMenu.vue';
 
@@ -158,6 +171,7 @@ export default {
   computed: {
     loggedIn,
     insideIFrame,
+    cookiesEnabled,
     returnObject() {
       const { name, query, params } = this.$route;
       return JSON.stringify({ name, query, params });

--- a/src/components/DandiFooter.vue
+++ b/src/components/DandiFooter.vue
@@ -1,6 +1,7 @@
 <script>
 import { copyToClipboard } from '@/utils';
 import { dandiAboutUrl } from '@/utils/constants';
+import { cookiesEnabled } from '@/rest';
 
 import CookieLaw from 'vue-cookie-law';
 
@@ -12,6 +13,8 @@ export default {
     dandiAboutUrl,
   }),
   computed: {
+    cookiesEnabled,
+
     version() {
       return process.env.VUE_APP_VERSION;
     },
@@ -27,7 +30,9 @@ export default {
   methods: {
     versionClick() {
       this.copied = true;
-      setTimeout(() => { this.copied = false; }, 1000);
+      setTimeout(() => {
+        this.copied = false;
+      }, 1000);
       copyToClipboard(this.version);
     },
   },
@@ -39,7 +44,14 @@ export default {
     <v-container>
       <cookie-law theme="blood-orange">
         <div slot="message">
-          We use cookies to ensure you get the best experience on DANDI.
+          <span
+            v-if="cookiesEnabled"
+          >We use cookies to ensure you get the best experience on
+            DANDI.</span>
+          <span
+            v-else
+          >We noticed you're blocking cookies - note that certain aspects of
+            the site may not work.</span>
         </div>
       </cookie-law>
       <v-row>

--- a/src/rest/index.ts
+++ b/src/rest/index.ts
@@ -2,11 +2,13 @@ import publishRest from '@/rest/publish';
 
 const user = () => publishRest.user;
 const loggedIn = () => !!user();
-const insideIFrame = () => window.self !== window.top;
+const insideIFrame = (): boolean => window.self !== window.top;
+const cookiesEnabled = (): boolean => navigator.cookieEnabled;
 
 export {
   publishRest,
   loggedIn,
   user,
   insideIFrame,
+  cookiesEnabled,
 };


### PR DESCRIPTION
Previously, the site would crash and show a white screen if cookies were disabled by the user in their browser settings. This was due to both our Girder OAuth client and the vjsf library both assuming they have access to `localStorage` at all times (they don't have access when cookies are disabled). The issue in Girder OAuth client is fixed by this PR, and the issue with vjsf has been fixed upstream.

Now if cookies are disabled:
* the user will see a message warning about reduced functionality in place of the message notifying them about the use of cookies.
* the login button will be grayed out with a tooltip telling the user to enable cookies if they wish to login.

Closes #768 

To test out the changes, disable cookies in your browser settings.