### PR TITLE
Switch vjsf version back

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
     "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
-    "@mvandenburgh/vjsf": "^2.1.3-fork3",
+    "@koumoul/vjsf": "^2.2.1",
     "@sentry/browser": "^6.3.6",
     "@sentry/integrations": "^6.3.6",
     "@vue/composition-api": "^1.0.0-rc.8",

--- a/src/types/vjsf.d.ts
+++ b/src/types/vjsf.d.ts
@@ -1,1 +1,1 @@
-declare module '@mvandenburgh/vjsf/lib/VJsf';
+declare module '@koumoul/vjsf/lib/VJsf';

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -157,9 +157,9 @@ import {
 
 import jsYaml from 'js-yaml';
 
-import VJsf from '@mvandenburgh/vjsf/lib/VJsf';
-import '@mvandenburgh/vjsf/lib/deps/third-party';
-import '@mvandenburgh/vjsf/lib/VJsf.css';
+import VJsf from '@koumoul/vjsf/lib/VJsf';
+import '@koumoul/vjsf/lib/deps/third-party';
+import '@koumoul/vjsf/lib/VJsf.css';
 
 import { publishRest } from '@/rest';
 import { DandiModel, isJSONSchema } from '@/utils/schema/types';

--- a/src/views/DandisetLandingView/Meditor.vue
+++ b/src/views/DandisetLandingView/Meditor.vue
@@ -230,7 +230,7 @@ export default defineComponent({
 
     const CommonVJSFOptions = computed(() => ({
       initialValidation: 'all',
-      disablePrefilledArrays: true,
+      autoFixArrayItems: false,
       disableAll: props.readonly,
     }));
     const publishDandiset = computed(() => store.state.dandiset.publishDandiset);

--- a/vue.config.js
+++ b/vue.config.js
@@ -28,7 +28,7 @@ module.exports = {
   lintOnSave: false,
   transpileDependencies: [
     'vuetify',
-    '@mvandenburgh/vjsf',
+    '@koumoul/vjsf',
     '@girder/oauth-client',
   ],
   devServer: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,6 +1001,22 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@koumoul/vjsf@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@koumoul/vjsf/-/vjsf-2.2.1.tgz#8e657344c7c335603728428719940a4d5adaabcc"
+  integrity sha512-ShpYZVwU4vq1DlyNi3BCnIzSP3O9ZNN8Ov5zTFSOIe8FrdhztGyW1PNQmga2vSHJof89mVgIb9ZoDN5myKF3AQ==
+  dependencies:
+    "@mdi/js" "^5.5.55"
+    ajv "^6.12.0"
+    debounce "^1.2.0"
+    fast-copy "^2.1.1"
+    fast-equals "^2.0.0"
+    markdown-it "^8.4.2"
+    match-all "^1.2.5"
+    object-hash "^2.1.1"
+    property-expr "^1.5.1"
+    vuedraggable "^2.24.3"
+
 "@mdi/font@^5.3.45":
   version "5.9.55"
   resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
@@ -1018,22 +1034,6 @@
   dependencies:
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
-
-"@mvandenburgh/vjsf@^2.1.3-fork3":
-  version "2.1.3-fork3"
-  resolved "https://registry.yarnpkg.com/@mvandenburgh/vjsf/-/vjsf-2.1.3-fork3.tgz#681c4fd5bdf4efc79d1b714a661dd11c47f89844"
-  integrity sha512-33uNUQUTabHuP/8Rx+75STDS8q4TSygayWcgl8xQdlhL5/xnEzOMYu+pecWisuop98jgxFltGygC7RbeFoGq3A==
-  dependencies:
-    "@mdi/js" "^5.5.55"
-    ajv "^6.12.0"
-    debounce "^1.2.0"
-    fast-copy "^2.1.1"
-    fast-equals "^2.0.0"
-    markdown-it "^8.4.2"
-    match-all "^1.2.5"
-    object-hash "^2.1.1"
-    property-expr "^1.5.1"
-    vuedraggable "^2.24.3"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
Switch back to the [official vjsf npm package](https://www.npmjs.com/package/@koumoul/vjsf) now that the changes from [our custom fork](https://www.npmjs.com/package/@mvandenburgh/vjsf) have been released upstream.