### PR TITLE
Fix ownership

### DIFF
--- a/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -1,4 +1,3 @@
-<!-- TODO: Find way to clear v-autocomplete once selected-->
 <template>
   <v-card class="flex-grow-0">
     <v-card-title>Manage Ownership</v-card-title>
@@ -114,6 +113,10 @@ export default {
       // Verify that the selected user hasn't already been selected
       if (val && !this.newOwners.find((x) => x.username === val.username)) {
         this.newOwners.push(val);
+      }
+      // Clear the search field, if it isn't already
+      if (val) {
+        this.selection = '';
       }
     },
   },

--- a/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -37,7 +37,7 @@
           max-height="50vh"
         >
           <template v-for="(owner, i) in newOwners">
-            <v-list-item :key="owner._id || owner.id">
+            <v-list-item :key="owner.username">
               <v-list-item-title>
                 {{ owner.result }}
               </v-list-item-title>
@@ -50,7 +50,7 @@
                 </v-btn>
               </v-list-item-action>
             </v-list-item>
-            <v-divider :key="`${owner.id}-divider`" />
+            <v-divider :key="`${owner.username}-divider`" />
           </template>
         </v-list>
       </v-row>
@@ -111,8 +111,10 @@ export default {
   },
   watch: {
     selection(val) {
-      if (!val || this.newOwners.find((x) => x.id === val.id)) return;
-      this.newOwners.push(val);
+      // Verify that the selected user hasn't already been selected
+      if (val && !this.newOwners.find((x) => x.username === val.username)) {
+        this.newOwners.push(val);
+      }
     },
   },
   methods: {


### PR DESCRIPTION
Fixes #841 

At some point we apparently included the internal user ID in the
ownership description, which we then later removed. The ownership dialog
was keying off of `owner.id` for Vue rendering and for testing owner
uniqueness.

Use `username` (the GitHub username, guaranteed to be present) instead.

Also, the normal behavior for Vuetify autocompletes is (reasonably) to put the
selected text into the search field. We want to add the selected user to
a list, then clear the search field.

This also fixes a 400 error where the dialog box would search for the
pretty-printed username and find nothing.