### PR TITLE
Don't show delete button in file browser for published versions

### DIFF
--- a/src/views/FileBrowserView/PublishFileBrowser.vue
+++ b/src/views/FileBrowserView/PublishFileBrowser.vue
@@ -287,7 +287,7 @@ export default {
     },
 
     showDelete(item) {
-      return !item.folder && (this.isAdmin || this.isOwner);
+      return this.version === 'draft' && !item.folder && (this.isAdmin || this.isOwner);
     },
 
     async deleteAsset(item) {


### PR DESCRIPTION
Hides the delete button for published assets in the file browser view.

Closes #596.