### PR TITLE
Add more E2E tests

### DIFF
--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -19,6 +19,8 @@ beforeAll(async () => {
 // eslint-disable-next-line jest/require-top-level-describe
 beforeEach(async () => {
   await jestPuppeteer.resetBrowser();
+  // Widen the viewport to make sure puppeteer can see the full page. If we don't do this then part
+  // of the navbar will be collapsed into a hamburger menu, which will break some tests
   await page.setViewport({ width: 1366, height: 768 });
   await page.goto(CLIENT_URL, { timeout: 0 });
   await waitForRequestsToFinish();

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -19,6 +19,7 @@ beforeAll(async () => {
 // eslint-disable-next-line jest/require-top-level-describe
 beforeEach(async () => {
   await jestPuppeteer.resetBrowser();
+  await page.setViewport({ width: 1366, height: 768 });
   await page.goto(CLIENT_URL, { timeout: 0 });
   await waitForRequestsToFinish();
 });

--- a/test/package.json
+++ b/test/package.json
@@ -12,6 +12,7 @@
     "jest": "^26.6.3",
     "jest-puppeteer": "^5.0.3",
     "jest-puppeteer-vuetify": "0.1.3",
+    "moment": "^2.29.1",
     "puppeteer": "^9.1.1"
   },
   "devDependencies": {

--- a/test/src/pages/homePage.js
+++ b/test/src/pages/homePage.js
@@ -6,7 +6,7 @@ import { vIcon, vTextField } from 'jest-puppeteer-vuetify';
  * @param {String} stat the stat to check
  */
 export async function getStat(stat) {
-  await page.waitFor(1000);
+  await page.waitForTimeout(1000);
   return page.$eval(`[data-id="stat"][data-name="${stat}"] [data-id="value"]`, (element) => Number(element.innerText));
 }
 
@@ -19,5 +19,5 @@ export async function search(query) {
   await expect(page).toFillXPath(vTextField('Search Dandisets by name, description, identifier, or contributor name'), query);
   await expect(page).toClickXPath(vIcon('mdi-magnify'));
   // TODO figure out a dynamic wait
-  await page.waitFor(2000);
+  await page.waitForTimeout(2000);
 }

--- a/test/src/pages/searchPage.js
+++ b/test/src/pages/searchPage.js
@@ -14,7 +14,7 @@ export async function search(query) {
   await expect(page).toFillXPath(vToolbar() + vTextField(), query);
   await expect(page).toClickXPath(vIcon('mdi-magnify'));
   // TODO figure out a dynamic wait
-  await page.waitFor(2000);
+  await page.waitForTimeout(2000);
 }
 
 /**

--- a/test/src/tests/account.test.js
+++ b/test/src/tests/account.test.js
@@ -13,6 +13,7 @@ describe('account management', () => {
     await registerNewUser();
 
     await expect(page).toClickXPath(vAvatar('??'));
+    await page.waitForTimeout(500);
     await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
 
     // this text is only displayed when not logged in

--- a/test/src/tests/cookies.test.js
+++ b/test/src/tests/cookies.test.js
@@ -1,5 +1,4 @@
-import { vBtn } from 'jest-puppeteer-vuetify';
-import { disableAllCookies, LOGIN_BUTTON_TEXT } from '../util';
+import { disableAllCookies } from '../util';
 
 const COOKIE_CONSENT_MESSAGE = 'We use cookies to ensure you get the best experience on DANDI.';
 const COOKIE_DISABLED_MESSAGE = 'We noticed you\'re blocking cookies - note that certain aspects of the site may not work.';
@@ -20,8 +19,5 @@ describe('cookie usage text', () => {
     await expect(page).toMatch(COOKIE_DISABLED_MESSAGE);
     await page.click('button.Cookie__button');
     await expect(page).not.toMatch(COOKIE_DISABLED_MESSAGE);
-
-    // TODO: check that this button is disabled too
-    await expect(page).toContainXPath(vBtn(LOGIN_BUTTON_TEXT));
   });
 });

--- a/test/src/tests/cookies.test.js
+++ b/test/src/tests/cookies.test.js
@@ -1,0 +1,27 @@
+import { vBtn } from 'jest-puppeteer-vuetify';
+import { disableAllCookies, LOGIN_BUTTON_TEXT } from '../util';
+
+const COOKIE_CONSENT_MESSAGE = 'We use cookies to ensure you get the best experience on DANDI.';
+const COOKIE_DISABLED_MESSAGE = 'We noticed you\'re blocking cookies - note that certain aspects of the site may not work.';
+
+describe('cookie usage text', () => {
+  it('click cookie usage acknowledgement', async () => {
+    // Ensure that the cookie consent message is visible and disappears after button is clicked
+    await expect(page).toMatch(COOKIE_CONSENT_MESSAGE);
+    await page.click('button.Cookie__button');
+    await expect(page).not.toMatch(COOKIE_CONSENT_MESSAGE);
+  });
+
+  it('test when cookies are disabled', async () => {
+    // disable cookies
+    await disableAllCookies();
+
+    // Ensure that the cookie disabled message is visible and disappears after button is clicked
+    await expect(page).toMatch(COOKIE_DISABLED_MESSAGE);
+    await page.click('button.Cookie__button');
+    await expect(page).not.toMatch(COOKIE_DISABLED_MESSAGE);
+
+    // TODO: check that this button is disabled too
+    await expect(page).toContainXPath(vBtn(LOGIN_BUTTON_TEXT));
+  });
+});

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -2,7 +2,7 @@ import {
   vBtn, vListItem, vChip
 } from 'jest-puppeteer-vuetify';
 import {
-  uniqueId, registerNewUser, registerDandiset, logout, waitForRequestsToFinish,
+  uniqueId, registerNewUser, registerDandiset, logout, waitForRequestsToFinish, clearCookiesAndCache,
 } from '../util';
 
 describe('dandiset landing page', () => {
@@ -10,9 +10,7 @@ describe('dandiset landing page', () => {
     const { email: otherUser } = await registerNewUser();
     await logout();
 
-    const client = await page.target().createCDPSession();
-    await client.send('Network.clearBrowserCookies');
-    await client.send('Network.clearBrowserCache');
+    await clearCookiesAndCache();
 
     const { email: owner } = await registerNewUser();
 

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -1,8 +1,13 @@
 import {
-  vBtn, vListItem, vChip
+  vBtn, vListItem, vChip,
 } from 'jest-puppeteer-vuetify';
 import {
-  uniqueId, registerNewUser, registerDandiset, logout, waitForRequestsToFinish, clearCookiesAndCache,
+  uniqueId,
+  registerNewUser,
+  registerDandiset,
+  logout,
+  waitForRequestsToFinish,
+  clearCookiesAndCache,
 } from '../util';
 
 describe('dandiset landing page', () => {

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -1,5 +1,5 @@
 import {
-  vBtn, vListItem, vChip,
+  vBtn, vChip, vListItem,
 } from 'jest-puppeteer-vuetify';
 import {
   uniqueId,
@@ -39,9 +39,8 @@ describe('dandiset landing page', () => {
     // owner should be in the list of owners
     await expect(page).toMatch(owner);
 
-    // TODO: find a better way to do this (not using keyboard shortcuts)
-    await page.keyboard.press('Tab');
-    await page.type('.v-text-field__slot', otherUser);
+    // search for otherUser and add them as an owner
+    await expect(page).toFillXPath('//input[@placeholder="Search by first name, last name or username"]', otherUser);
     await waitForRequestsToFinish();
     await expect(page).toClickXPath(vListItem(otherUser));
 

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -1,5 +1,5 @@
 import {
-  vBtn, vListItem,
+  vBtn, vListItem, vChip
 } from 'jest-puppeteer-vuetify';
 import {
   uniqueId, registerNewUser, registerDandiset, logout, waitForRequestsToFinish,
@@ -7,14 +7,14 @@ import {
 
 describe('dandiset landing page', () => {
   it('add an owner to a dandiset', async () => {
-    const { username: otherUser } = await registerNewUser();
+    const { email: otherUser } = await registerNewUser();
     await logout();
 
     const client = await page.target().createCDPSession();
     await client.send('Network.clearBrowserCookies');
     await client.send('Network.clearBrowserCache');
 
-    const { username: owner } = await registerNewUser();
+    const { email: owner } = await registerNewUser();
 
     const id = uniqueId();
     const name = `name ${id}`;
@@ -22,6 +22,10 @@ describe('dandiset landing page', () => {
     await registerDandiset(name, description);
 
     await waitForRequestsToFinish();
+
+    // "owner" should be the only owner
+    await expect(page).not.toContainXPath(vChip(otherUser));
+    await expect(page).toContainXPath(vChip(owner));
 
     // click the manage button, giving it some time to render
     await expect(page).toClickXPath(vBtn('Manage'));
@@ -43,6 +47,10 @@ describe('dandiset landing page', () => {
 
     await expect(page).toClickXPath(vBtn('Save Changes'));
 
-    // TODO: verify user shows up as owner in DLP
+    await waitForRequestsToFinish();
+
+    // otherUser should be an owner now, too
+    await expect(page).toContainXPath(vChip(otherUser));
+    await expect(page).toContainXPath(vChip(owner));
   });
 });

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -30,7 +30,7 @@ describe('dandiset landing page', () => {
     await expect(page).not.toContainXPath(vChip(otherUser));
     await expect(page).toContainXPath(vChip(owner));
 
-    // click the manage button, giving it some time to render
+    // click the manage button
     await expect(page).toClickXPath(vBtn('Manage'));
 
     // otherUser should not be in the list of owners (yet)

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -1,0 +1,48 @@
+import {
+  vBtn, vListItem,
+} from 'jest-puppeteer-vuetify';
+import {
+  uniqueId, registerNewUser, registerDandiset, logout, waitForRequestsToFinish,
+} from '../util';
+
+describe('dandiset landing page', () => {
+  it('add an owner to a dandiset', async () => {
+    const { username: otherUser } = await registerNewUser();
+    await logout();
+
+    const client = await page.target().createCDPSession();
+    await client.send('Network.clearBrowserCookies');
+    await client.send('Network.clearBrowserCache');
+
+    const { username: owner } = await registerNewUser();
+
+    const id = uniqueId();
+    const name = `name ${id}`;
+    const description = `description ${id}`;
+    await registerDandiset(name, description);
+
+    await waitForRequestsToFinish();
+
+    // click the manage button, giving it some time to render
+    await expect(page).toClickXPath(vBtn('Manage'));
+
+    // otherUser should not be in the list of owners (yet)
+    await expect(page).not.toMatch(otherUser);
+
+    // owner should be in the list of owners
+    await expect(page).toMatch(owner);
+
+    // TODO: find a better way to do this (not using keyboard shortcuts)
+    await page.keyboard.press('Tab');
+    await page.type('.v-text-field__slot', otherUser);
+    await waitForRequestsToFinish();
+    await expect(page).toClickXPath(vListItem(otherUser));
+
+    // otherUser should be in the list of owners now
+    await expect(page).toMatch(otherUser);
+
+    await expect(page).toClickXPath(vBtn('Save Changes'));
+
+    // TODO: verify user shows up as owner in DLP
+  });
+});

--- a/test/src/tests/dandisetsPage.test.js
+++ b/test/src/tests/dandisetsPage.test.js
@@ -1,0 +1,29 @@
+import { vBtn } from 'jest-puppeteer-vuetify';
+import moment from 'moment';
+import {
+  uniqueId,
+  registerNewUser,
+  registerDandiset,
+  waitForRequestsToFinish,
+  MY_DANDISETS_BTN_TEXT,
+} from '../util';
+
+describe('dandisets page', () => {
+  it('view "My Dandisets"', async () => {
+    // register user and create a new dandiset
+    const { firstName, lastName } = await registerNewUser();
+    const id = uniqueId();
+    const name = `name ${id}`;
+    const description = `description ${id}`;
+    const identifier = await registerDandiset(name, description);
+    await waitForRequestsToFinish();
+
+    await expect(page).toClickXPath(vBtn(MY_DANDISETS_BTN_TEXT));
+    await waitForRequestsToFinish();
+
+    await expect(page).toMatch(name);
+    await expect(page).toMatch(`DANDI:${identifier}`);
+    await expect(page).toMatch(`Contact ${lastName}, ${firstName}`);
+    await expect(page).toMatch(`Updated on ${moment(new Date()).format('LL')}`);
+  });
+});

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -1,5 +1,8 @@
 import {
+  vAvatar,
   vBtn,
+  vIcon,
+  vListItem,
   vTextField,
   vTextarea,
 } from 'jest-puppeteer-vuetify';
@@ -30,6 +33,14 @@ export async function waitForRequestsToFinish() {
  */
 export async function login() {
   await expect(page).toClickXPath(vBtn(LOGIN_BUTTON_TEXT));
+}
+
+/**
+ * Log out a user
+ */
+export async function logout() {
+  await expect(page).toClickXPath(vAvatar('??'));
+  await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
 }
 
 /**

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -80,7 +80,9 @@ export async function registerNewUser() {
   await page.goto(CLIENT_URL, { timeout: 0 });
   await waitForRequestsToFinish();
 
-  return { username, email, password, firstName, lastName };
+  return {
+    username, email, password, firstName, lastName,
+  };
 }
 
 /**

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -100,3 +100,13 @@ export async function clearCookiesAndCache() {
   await client.send('Network.clearBrowserCookies');
   await client.send('Network.clearBrowserCache');
 }
+
+/**
+ * Disables all cookies (3rd party and otherwise) in the current browser session.
+ */
+export async function disableAllCookies() {
+  const client = await page.target().createCDPSession();
+  await client.send('Emulation.setDocumentCookieDisabled', { disabled: true });
+  await page.reload();
+  await waitForRequestsToFinish();
+}

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -40,7 +40,7 @@ export async function login() {
  */
 export async function logout() {
   await expect(page).toClickXPath(vAvatar('??'));
-  await page.waitFor(500);
+  await page.waitForTimeout(500);
   await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
 }
 

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -11,6 +11,7 @@ export const { CLIENT_URL } = process.env;
 
 export const LOGIN_BUTTON_TEXT = 'Log In with GitHub';
 export const LOGOUT_BUTTON_TEXT = 'Logout';
+export const MY_DANDISETS_BTN_TEXT = 'My Dandisets';
 
 export function uniqueId() {
   // TODO think of something cleaner
@@ -33,15 +34,6 @@ export async function waitForRequestsToFinish() {
  */
 export async function login() {
   await expect(page).toClickXPath(vBtn(LOGIN_BUTTON_TEXT));
-}
-
-/**
- * Log out a user
- */
-export async function logout() {
-  await expect(page).toClickXPath(vAvatar('??'));
-  await page.waitForTimeout(500);
-  await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
 }
 
 /**
@@ -119,4 +111,14 @@ export async function disableAllCookies() {
   await client.send('Emulation.setDocumentCookieDisabled', { disabled: true });
   await page.reload();
   await waitForRequestsToFinish();
+}
+
+/**
+ * Log out a user
+ */
+export async function logout() {
+  await expect(page).toClickXPath(vAvatar('??'));
+  await page.waitForTimeout(500);
+  await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
+  await clearCookiesAndCache();
 }

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -47,12 +47,17 @@ export async function logout() {
 /**
  * Register a new user with a random username.
  *
- * @returns {object} { username, email, password }
+ * @returns {object} { username, email, password, firstName, lastName }
  */
 export async function registerNewUser() {
   const username = `user${uniqueId()}`;
   const email = `mr${username}@dandi.test`;
   const password = 'XtR4-S3curi7y-p4sSw0rd'; // Top secret
+
+  // there's currently no way to set these in development mode,
+  // so they are always empty strings by default
+  const firstName = '';
+  const lastName = '';
 
   await expect(page).toClickXPath(vBtn(LOGIN_BUTTON_TEXT));
 
@@ -75,7 +80,7 @@ export async function registerNewUser() {
   await page.goto(CLIENT_URL, { timeout: 0 });
   await waitForRequestsToFinish();
 
-  return { username, email, password };
+  return { username, email, password, firstName, lastName };
 }
 
 /**
@@ -83,6 +88,8 @@ export async function registerNewUser() {
  *
  * @param {string} name
  * @param {string} description
+ *
+ * @returns {string} identifier of the new dandiset
  */
 export async function registerDandiset(name, description) {
   await expect(page).toClickXPath(vBtn('New Dandiset'));
@@ -90,6 +97,7 @@ export async function registerDandiset(name, description) {
   await expect(page).toFillXPath(vTextarea('Description*'), description);
   await expect(page).toClickXPath(vBtn('Register dataset'));
   await waitForRequestsToFinish();
+  return page.url().split('/').pop();
 }
 
 /**

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -22,7 +22,7 @@ export function uniqueId() {
  */
 export async function waitForRequestsToFinish() {
   try {
-    await page.waitForNavigation({ waitUntil: 'networkidle0', timeout: 10000 });
+    await page.waitForNavigation({ waitUntil: 'networkidle0', timeout: 5000 });
   } catch (e) {
     // ignore
   }
@@ -40,6 +40,7 @@ export async function login() {
  */
 export async function logout() {
   await expect(page).toClickXPath(vAvatar('??'));
+  await page.waitFor(500);
   await expect(page).toClickXPath(vListItem(LOGOUT_BUTTON_TEXT, { action: vIcon('mdi-logout') }));
 }
 
@@ -54,8 +55,15 @@ export async function registerNewUser() {
   const password = 'XtR4-S3curi7y-p4sSw0rd'; // Top secret
 
   await expect(page).toClickXPath(vBtn(LOGIN_BUTTON_TEXT));
+
+  await waitForRequestsToFinish();
+
+  // puppeteer sometimes can't detect the signup link to click, so just navigate to it manually.
+  // This login/signup page is not used in production anyway, so we're not missing anything
+  // in terms of testing.
+  await page.goto(page.url().replace('/accounts/login', '/accounts/signup'));
+
   // API pages are not styled with Vuetify, so we can't use the vHelpers
-  await expect(page).toClickXPath('//a[@href="/accounts/signup/"]');
   await expect(page).toFillXPath('//input[@name="email"]', email);
   await expect(page).toFillXPath('//input[@name="password1"]', password);
   await expect(page).toFillXPath('//input[@name="password2"]', password);
@@ -66,8 +74,6 @@ export async function registerNewUser() {
 
   await page.goto(CLIENT_URL, { timeout: 0 });
   await waitForRequestsToFinish();
-
-  await login();
 
   return { username, email, password };
 }

--- a/test/src/util.js
+++ b/test/src/util.js
@@ -91,3 +91,12 @@ export async function registerDandiset(name, description) {
   await expect(page).toClickXPath(vBtn('Register dataset'));
   await waitForRequestsToFinish();
 }
+
+/**
+ * Clears browser cookies and cache.
+ */
+export async function clearCookiesAndCache() {
+  const client = await page.target().createCDPSession();
+  await client.send('Network.clearBrowserCookies');
+  await client.send('Network.clearBrowserCache');
+}

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -4139,6 +4139,11 @@ mkdirp-classic@^0.5.2:
   resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
   integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Add tests for
* Adding owners to a dandiset
* Cookie consent dialog/using DANDI with cookies disabled
* Viewing "My Dandisets" and verifying all information is correct and accounted for

I held off on adding tests for the meditor or specific features on the DLP like publishing, viewing asset files, etc. because they would have to be modified or rewritten once the DLP redesign is implemented.