### PR TITLE
Change order of E2E test spinup steps in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install web app
+          command: yarn install --frozen-lockfile
+      - run:
           name: Lint web app
           command: yarn run lint --no-fix
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install web app
-          command: yarn install --frozen-lockfile
-      - run:
           name: Lint web app
           command: yarn run lint --no-fix
 
@@ -28,6 +25,13 @@ jobs:
         name: rabbitmq
     steps:
       - checkout
+      - run:
+          name: Install web app
+          command: yarn install --frozen-lockfile
+      - run:
+          name: Run web app
+          command: yarn serve
+          background: true
       - run:
           name: Create virtual environment
           command: python3 -m venv install_env
@@ -70,13 +74,6 @@ jobs:
             DJANGO_STORAGE_BUCKET_NAME: dandi-bucket
             DJANGO_DANDI_DANDISETS_BUCKET_NAME: dandi-bucket
             DJANGO_CELERY_BROKER_URL: amqp://rabbitmq:5672/
-      - run:
-          name: Install web app
-          command: yarn install --frozen-lockfile
-      - run:
-          name: Run web app
-          command: yarn serve
-          background: true
       - run:
           name: Install E2E tests
           command: yarn install --frozen-lockfile


### PR DESCRIPTION
**~~yarn install is being executed twice in CI, once in test-gui and once in test-e2e. The E2E tests need to run it in order to spin up an instance of the web app, so remove it from test-gui. ~~**

I also moved up the installation and running of the web app to happen before the backend django server is spun up. This means CI will immediately fail if the web app fails to start or fails linting (as opposed to waiting for the django server to start, which takes longer than the web app).

The re-enabling of the E2E tests has made CI take much longer to run and it will continue to get longer as more tests are added in the future, so I think it's worth making this optimization. 