### PR TITLE
Fix crash if keywords or licenses are missing

### DIFF
--- a/src/views/DandisetLandingView/DandisetMain.vue
+++ b/src/views/DandisetLandingView/DandisetMain.vue
@@ -102,7 +102,7 @@
             class="mb-4"
           >
             <v-card-text
-              v-if="meta.keywords.length"
+              v-if="meta.keywords && meta.keywords.length"
               style="border-bottom: thin solid rgba(0, 0, 0, 0.12);"
             >
               Keywords:
@@ -116,7 +116,7 @@
               </v-chip>
             </v-card-text>
 
-            <v-card-text v-if="meta.license.length">
+            <v-card-text v-if="meta.license && meta.license.length">
               Licenses:
               <v-chip
                 v-for="(license, i) in meta.license"


### PR DESCRIPTION
This doesn't really affect production since keywords and licenses are always initialized as an empty array (unless a user goes into the swagger page and manually removes those properties). But, this can happen locally if you're messing around in the admin console, or if you use the `create_dev_dandiset` command which doesn't populate these fields.

I always forget that empty arrays evaluate to `true` in JS. :angry: 