### PR TITLE
changing download/cite buttons

### DIFF
--- a/src/views/DandisetLandingView/DandisetActions.vue
+++ b/src/views/DandisetLandingView/DandisetActions.vue
@@ -31,9 +31,6 @@
               </v-icon>
               Download
               <v-spacer />
-              <v-icon right>
-                mdi-chevron-down
-              </v-icon>
             </v-btn>
           </template>
         </DownloadDialog>
@@ -58,9 +55,6 @@
               </v-icon>
               Cite As
               <v-spacer />
-              <v-icon right>
-                mdi-chevron-down
-              </v-icon>
             </v-btn>
           </template>
         </CiteAsDialog>


### PR DESCRIPTION
changing buttons for `download` and `cite as`: removing "down arrows" 

partially addressing #865 