### PR TITLE
Restore old ownership ui + modify button

### DIFF
--- a/src/views/DandisetLandingView/DandisetOwners.vue
+++ b/src/views/DandisetLandingView/DandisetOwners.vue
@@ -1,181 +1,145 @@
 <template>
   <v-card
-    v-if="currentDandiset"
-    height="100%"
-    class="px-3 py-1"
     outlined
+    class="mt-4 px-3 pb-5"
   >
     <v-row
       no-gutters
-      class="my-1 ml-1"
+      class="my-1"
     >
-      <div class="black--text text-h5">
-        Ownership
-      </div>
-    </v-row>
-    <v-row>
-      <v-tooltip
-        v-if="showOwnerSearchBox"
-        top
-        :disabled="userCanModifyDandiset"
-      >
-        <template #activator="{ on }">
-          <div v-on="on">
-            <v-row class="mx-2 px-2">
-              <v-autocomplete
-                v-model="selection"
-                :items="items"
-                :disabled="!userCanModifyDandiset"
-                :loading="loadingUsers"
-                :search-input.sync="search"
-                hide-no-data
-                clearable
-                auto-select-first
-                item-text="result"
-                placeholder="enter email address"
-                outlined
-                flat
-                return-object
-                @update:search-input="throttledUpdate"
-              />
-            </v-row>
-          </div>
-        </template>
-        <template v-if="loggedIn">
-          You must be an owner to manage ownership.
-        </template>
-        <template v-else>
-          You must be logged in to manage ownership.
-        </template>
-      </v-tooltip>
       <v-row
-        v-if="owners && owners.length"
-        class="mx-2 px-2"
+        no-gutters
+        class="my-1 ml-1"
       >
+        <div class="black--text text-h5">
+          Owners
+        </div>
+      </v-row>
+    </v-row>
+
+    <v-row class="my-1">
+      <v-col cols="12">
         <v-chip
-          v-for="(owner, i) in newOwners"
-          :key="i"
-          color="light-blue lighten-4"
-          text-color="light-blue darken-3"
+          v-for="(owner, i) in limitedOwners"
+          :key="owner.name || owner.username"
+          color="grey lighten-4"
+          text-color="grey darken-2"
           class="font-weight-medium ma-1"
-          :close="userCanModifyDandiset"
-          @click:close="removeOwner(i)"
+          style="border: 1px solid #E0E0E0 !important;"
+          close-icon="mdi-star-circle"
+          :close="i === 0"
         >
           {{ owner.name || owner.username }}
         </v-chip>
-      </v-row>
+        <span
+          v-if="numExtraOwners"
+          class="ml-1 text--secondary"
+        >
+          +{{ numExtraOwners }} more...
+        </span>
+      </v-col>
+    </v-row>
 
-      <v-row
-        v-else
-        class="justify-center"
+    <v-row
+      class="justify-center"
+      no-gutters
+    >
+      <v-dialog
+        v-model="ownerDialog"
+        width="50%"
       >
-        No owners
-      </v-row>
+        <template #activator="{ on }">
+          <v-tooltip
+            :disabled="!manageOwnersDisabled"
+            left
+          >
+            <template #activator="{ on: tooltipOn }">
+              <div
+                style="width: 100%;"
+                v-on="tooltipOn"
+              >
+                <v-btn
+                  id="manage"
+                  depressed
+                  :disabled="manageOwnersDisabled"
+                  color="light-blue lighten-5"
+                  class="light-blue--text text--lighten-1 justify-start"
+                  block
+                  v-on="on"
+                >
+                  <v-icon
+                    class="pr-2"
+                  >
+                    mdi-account-plus
+                  </v-icon>
+                  Manage Owners
+                </v-btn>
+              </div>
+            </template>
+            <template v-if="loggedIn">
+              You must be an owner to manage ownership.
+            </template>
+            <template v-else>
+              You must be logged in to manage ownership.
+            </template>
+          </v-tooltip>
+        </template>
+        <DandisetOwnersDialog
+          :key="ownerDialogKey"
+          :owners="owners"
+          @close="ownerDialog = false"
+        />
+      </v-dialog>
     </v-row>
   </v-card>
 </template>
 
-<script lang="ts">
-import {
-  defineComponent, reactive, ref, computed, Ref, ComputedRef, watch,
-} from '@vue/composition-api';
+<script>
+import { mapState } from 'vuex';
+import { loggedIn, user } from '@/rest';
+import DandisetOwnersDialog from './DandisetOwnersDialog.vue';
 
-import { debounce } from 'lodash';
-
-import { draftVersion } from '@/utils/constants';
-import { dandiRest, loggedIn as loggedInFunc } from '@/rest';
-import store from '@/store';
-import { User } from '@/types';
-
-interface UserResult extends User {
-  result: string
-}
-
-// Includes a field `result` on each user which is the value displayed in the UI
-const appendResult = (users: User[]): UserResult[] => users?.map((u: User) => ({ ...u, result: (u.name) ? `${u.name} (${u.username})` : u.username }));
-
-export default defineComponent({
+export default {
   name: 'DandisetOwners',
-  props: {
-    userCanModifyDandiset: {
-      type: Boolean,
-      required: true,
-    },
+  components: {
+    DandisetOwnersDialog,
   },
-  setup() {
-    const currentDandiset = computed(() => store.state.dandiset.dandiset);
-    const owners = computed(() => store.state.dandiset.owners);
-
-    const search = ref('');
-    const loadingUsers = ref(false);
-    const selection: Ref<UserResult|null> = ref(null);
-    const items: Ref<User[]> = ref([]);
-
-    const newOwners: UserResult[] = reactive([]);
-    watch(() => owners.value, () => (
-      owners.value ? Object.assign(newOwners, appendResult(owners.value)) : null),
-    { immediate: true });
-
-    const loggedIn: ComputedRef<boolean> = computed(loggedInFunc);
-
-    const showOwnerSearchBox = computed(
-      // Only show the search box to logged in users on DRAFT versions
-      () => loggedIn.value && currentDandiset.value?.version === draftVersion,
-    );
-
-    function setOwners(ownersToSet: User[]) {
-      store.commit.dandiset.setOwners(ownersToSet);
-    }
-
-    const throttledUpdate = debounce((async () => {
-      if (!search.value) return;
-
-      loadingUsers.value = true;
-      const users = await dandiRest.searchUsers(search.value);
-      items.value = appendResult(users);
-      loadingUsers.value = false;
-    }), 200);
-
-    async function save() {
-      if (currentDandiset.value?.dandiset) {
-        const { identifier } = currentDandiset.value.dandiset;
-        const { data } = await dandiRest.setOwners(identifier, newOwners);
-        setOwners(data);
-      }
-    }
-
-    async function removeOwner(index: number) {
-      newOwners.splice(index, 1);
-      await save();
-    }
-
-    watch(selection, async () => {
-      // Verify that the selected user hasn't already been selected
-      if (selection.value && !newOwners.find((x) => x.username === selection.value?.username)) {
-        newOwners.push(selection.value);
-      }
-      // Clear the search field, if it isn't already
-      if (selection.value) {
-        selection.value = null;
-      }
-
-      await save();
-    });
-
+  data() {
     return {
-      currentDandiset,
-      owners,
-      selection,
-      items,
-      loadingUsers,
-      search,
-      throttledUpdate,
-      loggedIn,
-      newOwners,
-      removeOwner,
-      draftVersion,
-      showOwnerSearchBox,
+      labelClasses: 'mx-2 text--secondary',
+      itemClasses: 'font-weight-medium',
+      ownerDialog: false,
+      ownerDialogKey: 0,
     };
   },
-});
+  computed: {
+    user,
+    loggedIn,
+    currentDandiset() {
+      return this.currentDandiset;
+    },
+    manageOwnersDisabled() {
+      if (!this.loggedIn || !this.owners) return true;
+      return !this.owners.find((owner) => owner.username === this.user.username);
+    },
+    limitedOwners() {
+      if (!this.owners) return [];
+      return this.owners.slice(0, 5);
+    },
+    numExtraOwners() {
+      if (!this.owners) return 0;
+      return this.owners.length - this.limitedOwners.length;
+    },
+    ...mapState('dandiset', {
+      currentDandiset: (state) => state.dandiset,
+      owners: (state) => state.owners,
+    }),
+  },
+  watch: {
+    ownerDialog() {
+      // This is incremented to force re-render of the owner dialog
+      this.ownerDialogKey += 1;
+    },
+  },
+};
 </script>

--- a/src/views/DandisetLandingView/DandisetOwnersDialog.vue
+++ b/src/views/DandisetLandingView/DandisetOwnersDialog.vue
@@ -1,0 +1,152 @@
+<template>
+  <v-card class="flex-grow-0">
+    <v-card-title>Manage Ownership</v-card-title>
+    <template v-if="!owners || !owners.length">
+      <v-row
+        align="center"
+        justify="center"
+        class="mx-1"
+      >
+        No owners
+      </v-row>
+    </template>
+    <template v-else>
+      <v-row class="mx-1 px-6">
+        <v-autocomplete
+          v-model="selection"
+          :items="items"
+          :loading="loadingUsers"
+          :search-input.sync="search"
+          hide-no-data
+          clearable
+          auto-select-first
+          item-text="result"
+          placeholder="Search by first name, last name or username"
+          outlined
+          flat
+          return-object
+          @update:search-input="throttledUpdate"
+        />
+      </v-row>
+      <v-row class="mx-1">
+        <v-list
+          width="100%"
+          style="overflow-y: auto;"
+          class="px-6"
+          max-height="50vh"
+        >
+          <template v-for="(owner, i) in newOwners">
+            <v-list-item :key="owner.username">
+              <v-list-item-title>
+                {{ owner.result }}
+              </v-list-item-title>
+              <v-list-item-action>
+                <v-btn
+                  icon
+                  @click="removeOwner(i)"
+                >
+                  <v-icon>mdi-close</v-icon>
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+            <v-divider :key="`${owner.username}-divider`" />
+          </template>
+        </v-list>
+      </v-row>
+    </template>
+    <v-row
+      justify="end"
+      align="end"
+      class="mx-1 pt-4 pb-2"
+    >
+      <v-btn
+        tile
+        text
+        @click="close"
+      >
+        Cancel
+      </v-btn>
+      <v-btn
+        tile
+        text
+        color="primary"
+        @click="save"
+      >
+        Save Changes
+      </v-btn>
+    </v-row>
+  </v-card>
+</template>
+
+<script>
+import _ from 'lodash';
+
+import { dandiRest, user } from '@/rest';
+import store from '@/store';
+
+// Includes a field `result` on each user which is the value displayed in the UI
+const appendResult = (users) => users.map((u) => ({ ...u, result: (u.name) ? `${u.name} (${u.username})` : u.username }));
+
+export default {
+  name: 'DandisetOwnersDialog',
+  props: {
+    owners: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      search: null,
+      loadingUsers: false,
+      selection: null,
+      newOwners: appendResult(this.owners),
+      items: [],
+      throttledUpdate: _.debounce(this.updateItems, 200),
+    };
+  },
+  computed: {
+    user,
+    currentDandiset() {
+      return store.state.dandiset.dandiset;
+    },
+  },
+  watch: {
+    selection(val) {
+      // Verify that the selected user hasn't already been selected
+      if (val && !this.newOwners.find((x) => x.username === val.username)) {
+        this.newOwners.push(val);
+      }
+      // Clear the search field, if it isn't already
+      if (val) {
+        this.selection = '';
+      }
+    },
+  },
+  methods: {
+    async updateItems() {
+      if (!this.search) return;
+
+      this.loadingUsers = true;
+      const users = await dandiRest.searchUsers(this.search);
+      this.items = appendResult(users);
+      this.loadingUsers = false;
+    },
+    removeOwner(index) {
+      this.newOwners.splice(index, 1);
+    },
+    close() {
+      this.$emit('close');
+    },
+    async save() {
+      const { identifier } = this.currentDandiset.dandiset;
+      const { data } = await dandiRest.setOwners(identifier, this.newOwners);
+      this.setOwners(data);
+      this.close();
+    },
+    setOwners(owners) {
+      store.commit.dandiset.setOwners(owners);
+    },
+  },
+};
+</script>

--- a/test/src/tests/dandisetLandingPage.test.js
+++ b/test/src/tests/dandisetLandingPage.test.js
@@ -1,4 +1,6 @@
-import { vChip, vListItem } from 'jest-puppeteer-vuetify';
+import {
+  vBtn, vChip, vListItem,
+} from 'jest-puppeteer-vuetify';
 import {
   uniqueId,
   registerNewUser,
@@ -28,10 +30,24 @@ describe('dandiset landing page', () => {
     await expect(page).not.toContainXPath(vChip(otherUser));
     await expect(page).toContainXPath(vChip(owner));
 
+    // click the manage button
+    await expect(page).toClickXPath(vBtn('Manage Owners'));
+
+    // otherUser should not be in the list of owners (yet)
+    await expect(page).not.toMatch(otherUser);
+
+    // owner should be in the list of owners
+    await expect(page).toMatch(owner);
+
     // search for otherUser and add them as an owner
-    await expect(page).toFillXPath('//input[@placeholder="enter email address"]', otherUser);
+    await expect(page).toFillXPath('//input[@placeholder="Search by first name, last name or username"]', otherUser);
     await waitForRequestsToFinish();
     await expect(page).toClickXPath(vListItem(otherUser));
+
+    // otherUser should be in the list of owners now
+    await expect(page).toMatch(otherUser);
+
+    await expect(page).toClickXPath(vBtn('Save Changes'));
 
     await waitForRequestsToFinish();
 


### PR DESCRIPTION
Partially fixes #863.

For the most part, this PR just restores the old ownership management dialog, which is closer to what Jared's new design looks like. Per the new design, I also moved the "Manage Ownership" button to underneath the owner list and restyled it.

I will make a follow-up PR that actually implements Jared's design in it's entirety. Since the new design is a major change to how we handle ownership management in the UI, I'd like to do this incrementally in the interest of keeping PR diff sizes low.