### PR TITLE
Adjust styling on dandiset action buttons

### DIFF
--- a/src/views/DandisetLandingView/DandisetActions.vue
+++ b/src/views/DandisetLandingView/DandisetActions.vue
@@ -29,7 +29,7 @@
               >
                 mdi-download
               </v-icon>
-              Download
+              <span>Download</span>
               <v-spacer />
               <v-icon right>
                 mdi-chevron-down
@@ -56,7 +56,7 @@
               >
                 mdi-format-quote-close
               </v-icon>
-              Cite As
+              <span>Cite As</span>
               <v-spacer />
               <v-icon right>
                 mdi-chevron-down
@@ -82,7 +82,7 @@
           >
             mdi-folder
           </v-icon>
-          Files
+          <span>Files</span>
           <v-spacer />
         </v-btn>
       </v-row>
@@ -99,7 +99,7 @@
           >
             mdi-note-text
           </v-icon>
-          Metadata
+          <span>Metadata</span>
           <v-spacer />
         </v-btn>
       </v-row>
@@ -166,3 +166,11 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.v-btn--outlined {
+  border: thin solid #E0E0E0;
+  color: #424242;
+  font-weight: 400;
+}
+</style>


### PR DESCRIPTION
I missed this the first time around - right now the font weight and border color on the dandiset action buttons are slightly different then what is in the figma mockup. This PR restyles these components to match the mockup.

Current vs this PR (notice the changes under "Dandiset Actions")
![before](https://user-images.githubusercontent.com/37340715/138963831-cb748a05-d586-44a6-8f92-37dcf79189d4.png)
![after](https://user-images.githubusercontent.com/37340715/138963841-aa6a47fb-978e-496a-827a-adf9a63bc1ee.png)

