### PR TITLE
Remove girder web components dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "vue": "^2.6.11",
+    "vue-async-computed": "^3.9.0",
     "vue-cookie-law": "^1.13.3",
     "vue-gtag": "^1.16.1",
     "vue-router": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
     "vuex": "^3.6.2",
     "vuex-router-sync": "^5.0.0"
   },
-  "resolutions": {
-    "@girder/components/vuetify": "~2.3.6"
-  },
   "devDependencies": {
     "@types/js-yaml": "^4.0.1",
     "@types/json-schema": "^7.0.7",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.0.7",
-    "@girder/components": "~2.2.5",
     "@girder/oauth-client": "^0.7.7",
     "@koumoul/vjsf": "^2.5.2",
     "@sentry/browser": "^6.3.6",
@@ -28,7 +27,6 @@
     "vue": "^2.6.11",
     "vue-cookie-law": "^1.13.3",
     "vue-gtag": "^1.16.1",
-    "vue-json-pretty": "^1.8.0",
     "vue-router": "^3.5.1",
     "vue-social-sharing": "^3.0.8",
     "vuetify": "~2.3.6",

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import * as Integrations from '@sentry/integrations';
 // Import plugins first (order may matter)
 import '@/plugins/composition';
 import '@/plugins/asyncComputed';
+import vuetify from '@/plugins/vuetify';
 
 // Import custom behavior
 import '@/title';
@@ -21,7 +22,6 @@ import App from '@/App.vue';
 import router from '@/router';
 import store from '@/store';
 import { dandiRest } from '@/rest';
-import vuetify from './plugins/vuetify';
 
 Sentry.init({
   dsn: process.env.VUE_APP_SENTRY_DSN,

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import * as Integrations from '@sentry/integrations';
 
 // Import plugins first (order may matter)
 import '@/plugins/composition';
+import '@/plugins/asyncComputed';
 
 // Import custom behavior
 import '@/title';

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,13 +6,11 @@ import VueGtag from 'vue-gtag';
 import VueSocialSharing from 'vue-social-sharing';
 
 // @ts-ignore missing definitions
-import { vuetify } from '@girder/components/src';
 import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
 
 // Import plugins first (order may matter)
 import '@/plugins/composition';
-import '@/plugins/girder';
 
 // Import custom behavior
 import '@/title';
@@ -22,6 +20,7 @@ import App from '@/App.vue';
 import router from '@/router';
 import store from '@/store';
 import { dandiRest } from '@/rest';
+import vuetify from './plugins/vuetify';
 
 Sentry.init({
   dsn: process.env.VUE_APP_SENTRY_DSN,

--- a/src/plugins/asyncComputed.ts
+++ b/src/plugins/asyncComputed.ts
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import AsyncComputed from 'vue-async-computed';
+
+Vue.use(AsyncComputed);

--- a/src/plugins/girder.ts
+++ b/src/plugins/girder.ts
@@ -1,6 +1,0 @@
-import Vue from 'vue';
-
-// @ts-ignore missing definitions
-import Girder from '@girder/components/src';
-
-Vue.use(Girder);

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,0 +1,7 @@
+import Vue from 'vue';
+import Vuetify from 'vuetify/lib/framework';
+
+Vue.use(Vuetify);
+
+export default new Vuetify({
+});

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,7 +1,74 @@
 import Vue from 'vue';
 import Vuetify from 'vuetify/lib/framework';
 
+import colors from 'vuetify/lib/util/colors';
+
 Vue.use(Vuetify);
 
 export default new Vuetify({
+  // Use Girder web components theme
+  // https://github.com/girder/girder_web_components/blob/master/src/utils/vuetifyConfig.js
+  theme: {
+    dark: false,
+    options: {
+      customProperties: true,
+    },
+    themes: {
+      light: {
+        primary: colors.lightBlue.darken1,
+        secondary: colors.blueGrey.base,
+        accent: colors.lightBlue.darken1,
+        error: colors.red.base,
+        info: colors.lightBlue.lighten1,
+        dropzone: colors.grey.lighten3,
+        highlight: colors.yellow.lighten4,
+      },
+      dark: {
+        primary: colors.lightBlue.darken3,
+        secondary: colors.grey.base,
+        accent: colors.lightBlue.lighten1,
+        dropzone: colors.grey.darken2,
+        highlight: colors.grey.darken2,
+      },
+    },
+  },
+  icons: {
+    iconfont: 'mdi',
+    values: {
+      alert: 'mdi-alert-circle',
+      bitbucket: 'mdi-bitbucket',
+      box_com: 'mdi-package',
+      chevron: 'mdi-chevron-right',
+      circle: 'mdi-checkbox-blank-circle',
+      collection: 'mdi-file-tree',
+      download: 'mdi-download',
+      edit: 'mdi-pencil',
+      externalLink: 'mdi-open-in-new',
+      file: 'mdi-file',
+      fileMultiple: 'mdi-file-multiple',
+      fileNew: 'mdi-file-plus',
+      fileUpload: 'mdi-file-upload',
+      folder: 'mdi-folder',
+      folderNonPublic: 'mdi-folder-key',
+      folderNew: 'mdi-folder-plus',
+      github: 'mdi-github-circle',
+      globe: 'mdi-earth',
+      globus: 'mdi-earth',
+      google: 'mdi-google',
+      group: 'mdi-account-multiple',
+      item: 'mdi-file',
+      linkedin: 'mdi-linkedin',
+      lock: 'mdi-lock',
+      login: 'mdi-login',
+      logout: 'mdi-logout',
+      more: 'mdi-dots-horizontal',
+      otp: 'mdi-shield-key',
+      preview: 'mdi-file-find',
+      search: 'mdi-magnify',
+      settings: 'mdi-tune',
+      user: 'mdi-account',
+      userHome: 'mdi-home-account',
+      view: 'mdi-eye',
+    },
+  },
 });

--- a/src/types/shims-vuetify.d.ts
+++ b/src/types/shims-vuetify.d.ts
@@ -1,0 +1,5 @@
+declare module 'vuetify/lib/framework' {
+  import Vuetify from 'vuetify';
+
+  export default Vuetify;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9422,6 +9422,11 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+vue-async-computed@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/vue-async-computed/-/vue-async-computed-3.9.0.tgz#af3181c25168bfe9d86d8ffbc7033bf9e484fe84"
+  integrity sha512-ac6m/9zxHHNGGKNOU1en8qNk+fAmEbJLuWL7qyQTFuH3vjv3V4urv//QHcVzCobROM6btnaDG2b+XYMncF/ETA==
+
 vue-cli-plugin-vuetify@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.4.0.tgz#e3eca6a51592a1610b2006296efc31c52981b031"

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,21 +943,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@girder/components@~2.2.5":
-  version "2.2.10"
-  resolved "https://registry.yarnpkg.com/@girder/components/-/components-2.2.10.tgz#9588a76beb7fa595f096252241ebd54ff2de4683"
-  integrity sha512-eKDyrcnMVmeDo7pGe0JpRKVYoTK7J5aUq/fwy9zNDh7GXK5oeFmswp1gzpNWyiCcBmTIUMvlF4dK9XoiQ+B3Ew==
-  dependencies:
-    "@mdi/font" "^5.3.45"
-    axios "^0.19.2"
-    js-cookie "^2.2.0"
-    markdown-it "^11.0.0"
-    moment "^2.27.0"
-    qs "^6.9.4"
-    vue "^2.6.10"
-    vue-async-computed "^3.4.1"
-    vuetify "^2.3.1"
-
 "@girder/oauth-client@^0.7.7":
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/@girder/oauth-client/-/oauth-client-0.7.7.tgz#d18b890c4c72a00521089170406d7b6d3a27db92"
@@ -1028,11 +1013,6 @@
     object-hash "^2.1.1"
     property-expr "^2.0.4"
     vuedraggable "^2.24.3"
-
-"@mdi/font@^5.3.45":
-  version "5.9.55"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.9.55.tgz#41acd50b88073ded7095fc3029d8712b6e12f38e"
-  integrity sha512-jswRF6q3eq8NWpWiqct6q+6Fg/I7nUhrxYJfiEM8JJpap0wVJLQdbKtyS65GdlK7S7Ytnx3TTi/bmw+tBhkGmg==
 
 "@mdi/js@^5.5.55":
   version "5.9.55"
@@ -2280,13 +2260,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.21.2:
   version "0.21.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
@@ -3493,13 +3466,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.1, debug@^3.2.6:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -3902,11 +3868,6 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
-
-entities@~2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
-  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.8"
@@ -4656,13 +4617,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.13.3, follow-redirects@^1.14.0:
   version "1.14.4"
@@ -5813,11 +5767,6 @@ javascript-stringify@^2.0.1:
   resolved "https://registry.yarnpkg.com/javascript-stringify/-/javascript-stringify-2.1.0.tgz#27c76539be14d8bd128219a2d731b09337904e79"
   integrity sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==
 
-js-cookie@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
-  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
-
 js-message@1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/js-message/-/js-message-1.0.7.tgz#fbddd053c7a47021871bb8b2c95397cc17c20e47"
@@ -6059,13 +6008,6 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-linkify-it@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
-  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
-  dependencies:
-    uc.micro "^1.0.1"
-
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -6274,17 +6216,6 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-markdown-it@^11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-11.0.1.tgz#b54f15ec2a2193efa66dda1eb4173baea08993d6"
-  integrity sha512-aU1TzmBKcWNNYvH9pjq6u92BML+Hz3h5S/QpfTFwiQF852pLT+9qHsrhM9JYipkOXZxGn+sGH8oyJE9FD9WezQ==
-  dependencies:
-    argparse "^1.0.7"
-    entities "~2.0.0"
-    linkify-it "^3.0.1"
-    mdurl "^1.0.1"
-    uc.micro "^1.0.5"
 
 markdown-it@^8.4.2:
   version "8.4.2"
@@ -6554,7 +6485,7 @@ moment-locales-webpack-plugin@^1.2.0:
   dependencies:
     lodash.difference "^4.5.0"
 
-moment@^2.27.0, moment@^2.29.1:
+moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -7806,13 +7737,6 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
-qs@^6.9.4:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
-  dependencies:
-    side-channel "^1.0.4"
-
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -8457,15 +8381,6 @@ shelljs@^0.8.3:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
-
-side-channel@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
-  integrity sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==
-  dependencies:
-    call-bind "^1.0.0"
-    get-intrinsic "^1.0.2"
-    object-inspect "^1.9.0"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -9507,11 +9422,6 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vue-async-computed@^3.4.1:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/vue-async-computed/-/vue-async-computed-3.9.0.tgz#af3181c25168bfe9d86d8ffbc7033bf9e484fe84"
-  integrity sha512-ac6m/9zxHHNGGKNOU1en8qNk+fAmEbJLuWL7qyQTFuH3vjv3V4urv//QHcVzCobROM6btnaDG2b+XYMncF/ETA==
-
 vue-cli-plugin-vuetify@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/vue-cli-plugin-vuetify/-/vue-cli-plugin-vuetify-2.4.0.tgz#e3eca6a51592a1610b2006296efc31c52981b031"
@@ -9549,11 +9459,6 @@ vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"
   integrity sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==
-
-vue-json-pretty@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/vue-json-pretty/-/vue-json-pretty-1.8.0.tgz#de60ae70b4fcecc757567ba230a53afb46488f4a"
-  integrity sha512-0qyGHLBdQFIwVP04kjcEA7zmQ78w7hptjSz3zAZ/crIerLuHd/EXnBQzEJGz+eQHG7k3pJrZlEqVmhTDS70BoA==
 
 "vue-loader-v16@npm:vue-loader@^16.1.0":
   version "16.2.0"
@@ -9606,7 +9511,7 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^2.6.10, vue@^2.6.11:
+vue@^2.6.11:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
   integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
@@ -9627,7 +9532,7 @@ vuetify-loader@^1.7.2:
     file-loader "^6.2.0"
     loader-utils "^2.0.0"
 
-vuetify@^2.3.1, vuetify@~2.3.6:
+vuetify@~2.3.6:
   version "2.3.23"
   resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-2.3.23.tgz#1abd520c11e504bcae9a7299124727d83afef643"
   integrity sha512-JZc9mFYfxacsXTEM4zCwU6PW1inMEYyHjZdkWkGnPlW1OQwmme4FXMIISB3nPI7BE+wcEDtGfBGBtSqFEJkHSw==


### PR DESCRIPTION
Remove the Girder web components dependency from the project and configure Vuetify directly.

This PR does the following:
- Uninstalls GWC
- Installs the `vue-async-computed` package
  - This package was included with GWC, so we must now install it ourselves
  - Note that this dependency will go away after `FileBrowser.vue` is refactored to Composition API.
- Defines the Vuetify theme (colors, mostly) directly in `vuetify.ts`
  - This was another thing that GWC took care of for us. Having direct control over this will be useful as some of the theme may need to change as part of the DLP redesign.

Closes #670