### PR TITLE
Update the route on publish

### DIFF
--- a/src/views/DandisetLandingView/DandisetPublish.vue
+++ b/src/views/DandisetLandingView/DandisetPublish.vue
@@ -305,6 +305,7 @@ import moment from 'moment';
 
 import { dandiRest, loggedIn as loggedInFunc, user as userFunc } from '@/rest';
 import store from '@/store';
+import router from '@/router';
 import { User, Version } from '@/types';
 
 import { draftVersion, VALIDATION_ICONS } from '@/utils/constants';
@@ -453,10 +454,13 @@ export default defineComponent({
         }
 
         const version = await dandiRest.publish(currentDandiset.value.dandiset.identifier);
-        // re-initialize the dataset to load the newly published version
-        await store.dispatch.dandiset.initializeDandisets({
-          identifier: currentDandiset.value?.dandiset.identifier,
-          version: version.version,
+        // navigate to the newly published version
+        router.push({
+          name: 'dandisetLanding',
+          params: {
+            identifier: currentDandiset.value?.dandiset.identifier,
+            version: version.version,
+          },
         });
       }
     }


### PR DESCRIPTION
Previously, when the publish button was pressed, the store was modified
directly to show the newly published dandiset. This meant the route was
not updated, which puts the page in a weird state.

Use the router to navigate to newly published dandisets instead of
modifying the state directly.

Fixes #579 