### PR TITLE
Add empty and draft toggles to DandisetsPage

### DIFF
--- a/src/components/DandisetsPage.vue
+++ b/src/components/DandisetsPage.vue
@@ -1,13 +1,39 @@
 <template>
   <div v-page-title="pageTitle">
     <v-toolbar color="grey darken-2 white--text">
-      <v-toolbar-title class="d-none d-md-block">
-        {{ title }}
-      </v-toolbar-title>
-      <v-divider
-        class="d-none d-md-block"
-        vertical
-      />
+      <v-menu
+        offset-y
+        :close-on-content-click="false"
+      >
+        <template #activator="{ on, attrs }">
+          <v-icon
+            dark
+            v-bind="attrs"
+            v-on="on"
+          >
+            mdi-cog
+          </v-icon>
+        </template>
+        <v-list>
+          <v-list-item>
+            <v-list-item-title>Show:</v-list-item-title>
+          </v-list-item>
+          <v-list-item>
+            <v-switch
+              v-model="showDrafts"
+              label="Drafts"
+              dense
+            />
+          </v-list-item>
+          <v-list-item>
+            <v-switch
+              v-model="showEmpty"
+              label="Empty Dandisets"
+              dense
+            />
+          </v-list-item>
+        </v-list>
+      </v-menu>
       <div class="mx-6">
         Sort By:
       </div>
@@ -115,6 +141,8 @@ export default defineComponent({
     // https://next.router.vuejs.org/api/#useroute
     const route = ctx.root.$route;
 
+    const showDrafts = ref(false);
+    const showEmpty = ref(false);
     const sortOption = ref(Number(route.query.sortOption) || 0);
     const sortDir = ref(Number(route.query.sortDir || -1));
     const page = ref(Number(route.query.page) || 1);
@@ -133,6 +161,8 @@ export default defineComponent({
         ordering,
         user: props.user ? 'me' : null,
         search: props.search ? route.query.search : null,
+        draft: showDrafts.value,
+        empty: showEmpty.value,
       });
       djangoDandisetRequest.value = response.data;
     });
@@ -178,6 +208,8 @@ export default defineComponent({
     }
 
     return {
+      showDrafts,
+      showEmpty,
       sortingOptions,
       sortOption,
       sortDir,


### PR DESCRIPTION
These toggles control whether or not empty or draft dandisets are
displayed in the search. They both default to off.

This requires https://github.com/dandi/dandi-api/pull/607 before the branch preview will work.