### PR TITLE
Fix pip caching in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,32 +61,24 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Upgrade pip
-        run: pip install -U pip
-
-      - name: Install Python packages
+      - name: Install latest version of pip
         run: pip install --upgrade pip
 
       - name: Clone dandi-api
         run: git clone https://github.com/dandi/dandi-api.git
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@master
+        id: pip-cache
         with:
-          path: ~/.cache/pip
-          key: ${{ hashFiles('dandi-api/requirements.txt') }}-${{ hashFiles('dandi-api/setup.py') }}
+          path: ${{ env.pythonLocation}}/lib/python3.8/site-packages/*
+          key: ${{ env.pythonLocation }}-${{ hashFiles('dandi-api/requirements.txt') }}-${{ hashFiles('dandi-api/setup.py') }}
 
-      - name: Create virtual environment
-        run: python3 -m venv install_env
-
-      - name: Install dandi-api
-        run: |
-          source install_env/bin/activate
-          pip install --upgrade --upgrade-strategy eager ./dandi-api[dev]
+      - name: Install dandi-api dependencies
+        if: steps.pip-cache.outputs.cache-hit != 'true'
+        run: pip install --upgrade --upgrade-strategy eager ./dandi-api[dev]
 
       - name: Apply migrations to API server
-        run: |
-          source ../install_env/bin/activate
-          python manage.py migrate
+        run: python manage.py migrate
         working-directory: dandi-api
 
       - name: Install E2E tests
@@ -106,7 +98,6 @@ jobs:
           done
 
           # activate virtual env and start the dandi-api server
-          source ../install_env/bin/activate
           python ../dandi-api/manage.py runserver &
 
           # run the E2E tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             sleep 3
           done
 
-          # activate virtual env and start the dandi-api server
+          # start the dandi-api server
           python ../dandi-api/manage.py runserver &
 
           # run the E2E tests


### PR DESCRIPTION
The GitHub actions CI workflow doesn't cache pip wheels properly; currently, everything is downloaded and rebuilt from scratch on every PR or push to master. This PR fixes the CI config file so it caches the pip environment properly. This saves about a minute and a half for each CI run.

Comparison without/with caching:
https://github.com/dandi/dandiarchive/actions/runs/1517816471/attempts/1
https://github.com/dandi/dandiarchive/actions/runs/1517816471/attempts/2

Closes #982