### PR TITLE
Add test for dandiset identifier incrementing

### DIFF
--- a/test/src/tests/dandisetIdentifiers.test.js
+++ b/test/src/tests/dandisetIdentifiers.test.js
@@ -13,7 +13,7 @@ describe('ensures dandiset identifiers are incremented correctly', () => {
   it('creates a bunch of new dandisets while verifying that their IDs are correct', async () => {
     jest.setTimeout(60000 * 30); // Temporarily increase timeout to 30 mins for this test
 
-    // Create 2 users and create 500 dandisets with each of them
+    // Create 2 users and create 100 dandisets with each of them
     for (let i = 0; i < 2; i += 1) {
       // register user and create a new dandiset
       await registerNewUser();
@@ -26,7 +26,7 @@ describe('ensures dandiset identifiers are incremented correctly', () => {
 
       for (
         let latestIdentifier = Number(initialIdentifier);
-        latestIdentifier < Number(initialIdentifier) + 500;
+        latestIdentifier < Number(initialIdentifier) + 100;
         latestIdentifier += 1
       ) {
         const id = uniqueId();

--- a/test/src/tests/dandisetIdentifiers.test.js
+++ b/test/src/tests/dandisetIdentifiers.test.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-await-in-loop */
+
+import {
+  uniqueId,
+  registerNewUser,
+  registerDandiset,
+  waitForRequestsToFinish,
+  CLIENT_URL,
+  logout,
+} from '../util';
+
+describe('ensures dandiset identifiers are incremented correctly', () => {
+  it('creates a bunch of new dandisets while verifying that their IDs are correct', async () => {
+    jest.setTimeout(60000 * 30); // Temporarily increase timeout to 30 mins for this test
+
+    // Create 2 users and create 500 dandisets with each of them
+    for (let i = 0; i < 2; i += 1) {
+      // register user and create a new dandiset
+      await registerNewUser();
+      const initialId = uniqueId();
+      const initialName = `name ${initialId}`;
+      const initialDescription = `description ${initialId}`;
+      const initialIdentifier = await registerDandiset(initialName, initialDescription);
+      await page.goto(CLIENT_URL);
+      await waitForRequestsToFinish();
+
+      for (
+        let latestIdentifier = Number(initialIdentifier);
+        latestIdentifier < Number(initialIdentifier) + 500;
+        latestIdentifier += 1
+      ) {
+        const id = uniqueId();
+        const name = `name ${id}`;
+        const description = `description ${id}`;
+        const identifier = await registerDandiset(name, description);
+
+        expect(Number(identifier)).toBe(latestIdentifier + 1);
+
+        await page.goto(CLIENT_URL);
+        await waitForRequestsToFinish();
+      }
+      await logout();
+    }
+  });
+});


### PR DESCRIPTION
Closes #993.

This creates 1000 dandisets right now across two users. It might be a good idea to lower that number to decrease time it takes to run CI; I'm going to let it run first and see how long it takes.