### PR TITLE
Disable embargo dlp ui

### DIFF
--- a/src/views/DandisetLandingView/DandisetSidebar.vue
+++ b/src/views/DandisetLandingView/DandisetSidebar.vue
@@ -5,7 +5,7 @@
       :user-can-modify-dandiset="userCanModifyDandiset"
     />
 
-    <div v-if="currentDandiset.dandiset.embargo_status === 'OPEN'">
+    <div v-if="true">
       <DandisetPublish
         :user-can-modify-dandiset="userCanModifyDandiset"
       />


### PR DESCRIPTION
The `embargo_status` field doesn't exist in the prod server, so the ui is (incorrectly) rendering the Unembargo button for every dandiset.

Closes #1025 